### PR TITLE
fix(storybook): cache Fuse instance to prevent infinite render loop

### DIFF
--- a/app/src/js/core/models/emojis.ts
+++ b/app/src/js/core/models/emojis.ts
@@ -39,10 +39,12 @@ export class EmojiModel {
 export class EmojisModel {
   emojis: { [id: string]: EmojiModel };
   root: AppModel;
+  _fuse: Fuse<EmojiModel> | null = null;
 
   constructor(root: AppModel) {
     makeAutoObservable(this, {
       root: false,
+      _fuse: false,
     });
     this.root = root;
     this.emojis = {};
@@ -54,6 +56,7 @@ export class EmojisModel {
       Object.values(this.emojis).map((emoji) => emoji.dispose()),
     );
     this.emojis = {};
+    this._fuse = null;
   }
 
   upsert(emoji: Emoji) {
@@ -62,6 +65,7 @@ export class EmojisModel {
     } else {
       this.emojis[emoji.shortname].patch(emoji);
     }
+    this._fuse = null; // Invalidate cache when emojis change
   }
 
   load = flow(function* (this: EmojisModel) {
@@ -81,13 +85,16 @@ export class EmojisModel {
   }
 
   getFuse() {
-    return new Fuse(Object.values(this.emojis).filter((e: Emoji) => !e.empty), {
-      findAllMatches: true,
-      includeMatches: true,
-      keys: [
-        "name",
-        "shortname",
-      ],
-    });
+    if (!this._fuse) {
+      this._fuse = new Fuse(
+        Object.values(this.emojis).filter((e: Emoji) => !e.empty),
+        {
+          findAllMatches: true,
+          includeMatches: true,
+          keys: ["name", "shortname"],
+        },
+      );
+    }
+    return this._fuse;
   }
 }


### PR DESCRIPTION
## Summary

- Fixed EmojiSearch storybook causing browser to hang/freeze
- The issue was caused by `getFuse()` creating a new Fuse instance on every call
- Since `EmojiSearch` component's `useEffect` depends on `fuse`, this triggered an infinite re-render loop

## Changes

- Added `_fuse` cache field to `EmojisModel`
- `getFuse()` now returns cached instance, creating it only if needed
- Cache is invalidated when emojis change via `upsert()`
- Cache is cleared on `dispose()`

## Root Cause

1. Render → `getFuse()` returns new Fuse object
2. `useEffect` runs because `fuse` reference changed
3. `setResults()` triggers re-render
4. Go to step 1 → infinite loop → browser hang

## Test Plan

- [x] Open EmojiSearch storybook - should no longer freeze the browser
- [x] Verify emoji search functionality still works correctly
- [x] Verify emojis still update when new ones are added