### PR TITLE
chore(storybook): add missing component stories

### DIFF
--- a/app/src/js/components/molecules/DescriptionBar.stories.tsx
+++ b/app/src/js/components/molecules/DescriptionBar.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { DescriptionBar } from "./DescriptionBar.tsx";
+import { app } from "../../core/index.ts";
+
+const meta: Meta<typeof DescriptionBar> = {
+  component: DescriptionBar,
+  title: "Molecules/DescriptionBar",
+  parameters: {
+    layout: "padded",
+  },
+  loaders: [
+    async () => {
+      app.channels.upsert({
+        id: "channel-with-desc",
+        name: "general",
+        channelType: "PUBLIC",
+        users: [],
+        description: "This is the general channel for team discussions.",
+      });
+      app.channels.upsert({
+        id: "channel-long-desc",
+        name: "announcements",
+        channelType: "PUBLIC",
+        users: [],
+        description:
+          "This is a channel with a very long description that should be truncated when collapsed. It contains important information about company announcements, policy updates, and other critical communications that everyone should be aware of. Click to expand and read the full description.",
+      });
+      app.channels.upsert({
+        id: "channel-no-desc",
+        name: "random",
+        channelType: "PUBLIC",
+        users: [],
+      });
+    },
+  ],
+  argTypes: {
+    channelId: {
+      control: "select",
+      options: ["channel-with-desc", "channel-long-desc", "channel-no-desc"],
+      description: "ID of the channel to display description for",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DescriptionBar>;
+
+export const Default: Story = {
+  args: {
+    channelId: "channel-with-desc",
+  },
+};
+
+export const LongDescription: Story = {
+  args: {
+    channelId: "channel-long-desc",
+  },
+};
+
+export const NoDescription: Story = {
+  args: {
+    channelId: "channel-no-desc",
+  },
+};

--- a/app/src/js/components/organisms/Workspaces.stories.tsx
+++ b/app/src/js/components/organisms/Workspaces.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Workspaces } from "./Workspaces.tsx";
+
+const meta: Meta<typeof Workspaces> = {
+  component: Workspaces,
+  title: "Organisms/Workspaces",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "100vh", display: "flex" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {},
+};
+
+export default meta;
+type Story = StoryObj<typeof Workspaces>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/app/src/js/components/pages/PasswordResetPage.stories.tsx
+++ b/app/src/js/components/pages/PasswordResetPage.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PasswordResetPage } from "./PasswordResetPage.tsx";
+
+const meta: Meta<typeof PasswordResetPage> = {
+  component: PasswordResetPage,
+  title: "Pages/PasswordResetPage",
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    error: {
+      control: "text",
+      description: "Error message to display",
+    },
+    disabled: {
+      control: "boolean",
+      description: "Whether the form is disabled (loading state)",
+    },
+    onSubmit: {
+      action: "submitted",
+      description: "Called when the form is submitted",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PasswordResetPage>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const WithError: Story = {
+  args: {
+    error: "Old password is incorrect",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const PasswordMismatch: Story = {
+  args: {
+    error: "New password does not meet security requirements. Must be at least 8 characters.",
+  },
+};


### PR DESCRIPTION
## Summary
- Add PasswordResetPage story with Default, WithError, Loading, and PasswordMismatch variants
- Add Workspaces organism story with fullscreen layout
- Add DescriptionBar molecule story with app loader for context, including Default, LongDescription, and NoDescription variants

## Test plan
- [ ] Run `npm run storybook` and verify all 3 new stories render correctly
- [ ] Check PasswordResetPage stories show proper form states
- [ ] Check Workspaces story displays the logo and container
- [ ] Check DescriptionBar story handles channel descriptions with expand/collapse

🤖 Generated with [Claude Code](https://claude.ai/code)