### PR TITLE
fix: prevent blank screen when navigating to non-existent channels

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -201,6 +201,7 @@ Create standard story template with:
 
 ### 3.4 Error Handling Standardization
 **Problem:** Multiple error types without consistent handling
+- [x] Fix blank screen on non-existent/loading channels — `getThread()`/`getMessages()` now return null instead of throwing, Router gates on `isLoading`, channels upserted into store on navigation
 - [ ] Audit error classes in `deno/server/core/errors.ts` and `deno/server/inter/http/errors.ts`
 - [ ] Create unified error handling pattern
 - [ ] Standardize error responses across API
@@ -279,6 +280,7 @@ Create standard story template with:
 - [ ] **Channel files browser** - Dedicated view to browse/search all files shared in a channel
 - [ ] **Frontend observability** - Error reporting, logging, stats, and diagnostics dashboard
 - [ ] **Splash screen** - Add proper loading/splash screen on app startup
+- [ ] **Smooth channel loading transition** - Replace full-screen "Loading..." text with inline loading indicator in channel view to avoid screen blink when switching channels
 - [ ] **Release process** - Fix release workflow, consider bundled/binary distribution
 
 ---

--- a/app/src/js/components/Router.tsx
+++ b/app/src/js/components/Router.tsx
@@ -37,6 +37,7 @@ const RouteHandler = () => {
           console.log("Loading channel:", params.channelId);
           const channel = await client.api.getChannelById(params.channelId);
           if (!channel) throw new PageNotFoundError();
+          app.channels.upsert(channel);
           console.log("Channel loaded:", channel);
         } else {
           // Redirect to main channel if no channel specified
@@ -61,7 +62,7 @@ const RouteHandler = () => {
     return <ErrorPageS error={error} />;
   }
 
-  if (!app.initCompleted) {
+  if (isLoading || !app.initCompleted) {
     return <div>Loading...</div>;
   }
 

--- a/app/src/js/components/atoms/StatusLine.stories.tsx
+++ b/app/src/js/components/atoms/StatusLine.stories.tsx
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof StatusLine>;
 
 export const Primary: Story = {
   args: {
-    typing: app.getThread("123", null, { init: false }).typing,
+    typing: app.getThread("123", null, { init: false })!.typing,
     info: app.info,
   },
 };

--- a/app/src/js/components/layout/Desktop.tsx
+++ b/app/src/js/components/layout/Desktop.tsx
@@ -160,7 +160,7 @@ export const SideConversation = observer(
   ({ channelId, parentId }: SideConversationProps) => {
     const app = useApp();
     const threadModel = app.getThread(channelId, parentId);
-    if (!parentId) return null;
+    if (!parentId || !threadModel) return null;
     const message = threadModel.messages.get(parentId);
     const navigate = useNavigate();
 
@@ -228,8 +228,10 @@ export const MainConversation = observer(
     const channelModel = app.getChannel(channelId);
 
     useEffect(() => {
-      threadModel.init();
+      threadModel?.init();
     }, [channelId]);
+
+    if (!threadModel) return null;
 
     return (
       <MessageListArgsProvider streamId="main" value={location.state}>

--- a/app/src/js/components/layout/Mobile.tsx
+++ b/app/src/js/components/layout/Mobile.tsx
@@ -229,7 +229,7 @@ export const SideConversation = observer(
   ({ channelId, parentId }: SideConversationProps) => {
     const app = useApp();
     const threadModel = app.getThread(channelId, parentId);
-    if (!parentId) return null;
+    if (!parentId || !threadModel) return null;
     const message = threadModel.messages.get(parentId);
     const navigate = useNavigate();
     const { toggleSidebar } = useSidebar();
@@ -297,8 +297,10 @@ export const MainConversation = observer(
     const { toggleSidebar } = useSidebar();
 
     useEffect(() => {
-      threadModel.init();
+      threadModel?.init();
     }, [channelId]);
+
+    if (!threadModel) return null;
 
     return (
       <MessageListArgsProvider streamId="main" value={location.state}>

--- a/app/src/js/components/molecules/ActionButton.stories.tsx
+++ b/app/src/js/components/molecules/ActionButton.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof ActionButton> = {
       userId: "me",
       flat: "Hello, world!",
       message: { text: "Hello, world!" },
-    }, app.getMessages("test"));
+    }, app.getMessages("test")!);
     return (
       <MessageProvider value={message}>
         <ActionButton action={action} payload={payload} style={style}>

--- a/app/src/js/components/molecules/MessageInfo.stories.tsx
+++ b/app/src/js/components/molecules/MessageInfo.stories.tsx
@@ -60,7 +60,7 @@ export const InfoMessage: Story = {
         type: "info",
         msg: "Message delivered",
       },
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };
 
@@ -72,7 +72,7 @@ export const ErrorMessage: Story = {
         type: "error",
         msg: "Sending message failed",
       },
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };
 
@@ -85,7 +85,7 @@ export const WithAction: Story = {
         msg: "Sending message failed - click to retry",
         action: "resend",
       },
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };
 
@@ -93,6 +93,6 @@ export const NoInfo: Story = {
   args: {
     messageModel: MessageModel.from({
       ...BaseMessage,
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };

--- a/app/src/js/components/molecules/MessageInfo.tsx
+++ b/app/src/js/components/molecules/MessageInfo.tsx
@@ -12,7 +12,7 @@ export const MessageInfo = observer(
       if (info?.action === "resend") {
         app
           .getThread(messageModel.channelId, messageModel.parentId)
-          .resendMessage(messageModel);
+          ?.resendMessage(messageModel);
       }
     }, [clientId, info]);
 

--- a/app/src/js/components/molecules/MessageToolbar.stories.tsx
+++ b/app/src/js/components/molecules/MessageToolbar.stories.tsx
@@ -15,7 +15,7 @@ const createMessageModel = (overrides: any) => {
       channelId: "toolbar-test",
       ...overrides,
     },
-    app.getMessages("toolbar-test"),
+    app.getMessages("toolbar-test")!,
   );
 };
 

--- a/app/src/js/components/molecules/Reactions.stories.tsx
+++ b/app/src/js/components/molecules/Reactions.stories.tsx
@@ -13,7 +13,7 @@ const createMessageModel = () => {
       { userId: "me", reaction: "👍" },
       { userId: "you", reaction: "👎" },
     ],
-  }, app.getMessages("test"));
+  }, app.getMessages("test")!);
 };
 
 const meta: Meta<typeof Reactions> = {

--- a/app/src/js/components/organisms/Conversation.tsx
+++ b/app/src/js/components/organisms/Conversation.tsx
@@ -39,7 +39,7 @@ export const Conversation = observer(
       e.preventDefault();
       e.stopPropagation();
       const { files } = e.dataTransfer;
-      app.getThread(channelId, parentId).input.files.uploadMany(files);
+      app.getThread(channelId, parentId)?.input.files.uploadMany(files);
     }, [channelId, parentId]);
 
     const dragOverHandler = useCallback((ev: React.DragEvent) => {
@@ -52,7 +52,7 @@ export const Conversation = observer(
     }, [latest]);
 
     useEffect(() => {
-      app.getMessages(channelId, parentId).load();
+      app.getMessages(channelId, parentId)?.load();
     }, []);
 
     useEffect(() => {

--- a/app/src/js/components/organisms/Message.stories.tsx
+++ b/app/src/js/components/organisms/Message.stories.tsx
@@ -98,7 +98,7 @@ export const Primary: Story = {
   args: {
     model: MessageModel.from({
       ...BaseMessage,
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };
 
@@ -106,7 +106,7 @@ export const LongText: Story = {
   args: {
     model: MessageModel.from({
       ...LongTextMessage,
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };
 
@@ -124,7 +124,7 @@ export const WithThread: Story = {
           userId: "321",
         },
       ],
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };
 export const WithReaction: Story = {
@@ -145,7 +145,7 @@ export const WithReaction: Story = {
           reaction: ":thumbsdown:",
         },
       ],
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };
 
@@ -154,7 +154,7 @@ export const Ephemeral: Story = {
     model: MessageModel.from({
       ...BaseMessage,
       ephemeral: true,
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
   },
 };
 
@@ -162,7 +162,7 @@ export const Continuation: Story = {
   args: {
     model: MessageModel.from({
       ...BaseMessage,
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
     mode: "default",
     sameUser: true,
   },
@@ -177,7 +177,7 @@ export const EmojiOnly: Story = {
         emoji: ":thumbsup:",
       },
       emojiOnly: true,
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
     mode: "default",
   },
 };
@@ -198,7 +198,7 @@ export const WithImages: Story = {
           contentType: "image/jpeg",
         },
       ],
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
     mode: "default",
   },
 };
@@ -212,7 +212,7 @@ export const WithError: Story = {
         msg: "Sending message failed",
         action: "retry",
       },
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
     mode: "default",
   },
 };
@@ -253,7 +253,7 @@ export const WithLinkPreview: Story = {
           contentType: "text/html",
         },
       ],
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
     mode: "default",
   },
 };
@@ -290,7 +290,7 @@ export const WithLinkAnnotations: Story = {
           ],
         },
       ],
-    }, app.getMessages("test")),
+    }, app.getMessages("test")!),
     mode: "default",
   },
 };

--- a/app/src/js/core/models/app.ts
+++ b/app/src/js/core/models/app.ts
@@ -70,18 +70,13 @@ export class AppModel {
     opts: { init?: boolean } = {},
   ) {
     const channel = this.getChannel(channelId);
-    if (!channel) {
-      console.log(this);
-      throw new Error(`Channel with id ${channelId} not found`);
-    }
+    if (!channel) return null;
     return channel.getThread(parentId, { parentId, ...opts });
   }
 
   getMessages(channelId: string, parentId?: string | null) {
     const channel = this.getChannel(channelId);
-    if (!channel) {
-      throw new Error(`Channel with id ${channelId} not found`);
-    }
+    if (!channel) return null;
     return channel.getMessages(parentId);
   }
 

--- a/app/src/js/core/models/channels.ts
+++ b/app/src/js/core/models/channels.ts
@@ -38,6 +38,7 @@ export class ChannelsModel {
 
   find = flow(function* (this: ChannelsModel, id: string) {
     const channel = yield client.api.getChannelById(id);
+    if (!channel) return null;
     this.channels[channel.id] = new ChannelModel(channel, this.root);
   });
 

--- a/app/src/js/core/models/message.ts
+++ b/app/src/js/core/models/message.ts
@@ -219,7 +219,7 @@ export class MessageModel implements ViewMessage {
 
   async remove() {
     if (!this.root) throw new Error("Root not set");
-    await this.root.getMessages(this.channelId, this.parentId).remove(this.id);
+    await this.root.getMessages(this.channelId, this.parentId)?.remove(this.id);
   }
 
   addReaction = flow(function* (this: MessageModel, reaction: string) {


### PR DESCRIPTION
## Summary

- Gate Router render on `isLoading` to prevent components rendering before channel validation completes
- Upsert fetched channel into MobX store during route loading so it's available for rendering
- Change `getThread()` and `getMessages()` to return `null` instead of throwing when channel not found (consistent with `getPins`/`getSearch`)
- Add null guards in `SideConversation`, `MainConversation` (Desktop + Mobile), `Conversation`, and `MessageInfo` components
- Add null check in `channels.find()` for non-existent channel API responses

## Test plan

- [ ] Navigate to a non-existent channel ID (e.g. `/#/000000000000000000000000`) — should show 404 error page, not blank screen
- [ ] Navigate between valid channels — should load without crash
- [ ] Open a thread side panel — should render correctly
- [ ] TypeScript check passes (`cd app && npm run types`) — no new errors introduced