### PR TITLE
fix: prevent screen blink when switching channels

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -280,7 +280,7 @@ Create standard story template with:
 - [ ] **Channel files browser** - Dedicated view to browse/search all files shared in a channel
 - [ ] **Frontend observability** - Error reporting, logging, stats, and diagnostics dashboard
 - [ ] **Splash screen** - Add proper loading/splash screen on app startup
-- [ ] **Smooth channel loading transition** - Replace full-screen "Loading..." text with inline loading indicator in channel view to avoid screen blink when switching channels
+- [x] **Smooth channel loading transition** - Replace full-screen "Loading..." text with inline loading indicator in channel view to avoid screen blink when switching channels
 - [ ] **Release process** - Fix release workflow, consider bundled/binary distribution
 
 ---

--- a/app/src/js/components/Router.tsx
+++ b/app/src/js/components/Router.tsx
@@ -13,32 +13,31 @@ const RouteHandler = () => {
   const params = useParams();
   const { navigate } = useRouter();
   const [error, setError] = useState<Error | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isInitialLoading, setIsInitialLoading] = useState(!app.initCompleted);
 
   useEffect(() => {
     const loadRoute = async () => {
       try {
-        setIsLoading(true);
         setError(null);
 
         // Handle special routes
         if (params.isInvite || params.isReset) {
-          setIsLoading(false);
+          setIsInitialLoading(false);
           return;
         }
 
         // Initialize app if not already done
         await app.init();
-        console.log("App initialized:", app.initFailed);
         if (app.initFailed) throw new InitFailedError();
+        setIsInitialLoading(false);
 
         // Handle channel routes
         if (params.channelId) {
-          console.log("Loading channel:", params.channelId);
+          app.setLoading(true);
           const channel = await client.api.getChannelById(params.channelId);
+          app.setLoading(false);
           if (!channel) throw new PageNotFoundError();
           app.channels.upsert(channel);
-          console.log("Channel loaded:", channel);
         } else {
           // Redirect to main channel if no channel specified
           const { mainChannelId } = await client.api.getUserConfig() || {};
@@ -47,11 +46,9 @@ const RouteHandler = () => {
             return;
           }
         }
-
-        setIsLoading(false);
       } catch (err) {
         setError(err instanceof Error ? err : new Error("Unknown error"));
-        setIsLoading(false);
+        setIsInitialLoading(false);
       }
     };
 
@@ -62,7 +59,7 @@ const RouteHandler = () => {
     return <ErrorPageS error={error} />;
   }
 
-  if (isLoading || !app.initCompleted) {
+  if (isInitialLoading) {
     return <div>Loading...</div>;
   }
 


### PR DESCRIPTION
## Summary

- Replace full-screen `isLoading` gate with `isInitialLoading` that only blocks UI during first `app.init()` — not on every channel switch
- Channel fetch (`getChannelById`) now runs in the background using `app.setLoading()` for inline spinner, keeping the layout visible
- Removes debug `console.log` statements from the route handler

## Behavior changes

| Scenario | Before | After |
|----------|--------|-------|
| Switch between known channels | Full-screen "Loading..." blink | Instant — layout stays, content swaps |
| Navigate to uncached channel | Full-screen "Loading..." blink | Layout renders, inline spinner, then content |
| Navigate to non-existent channel | Full-screen "Loading..." then error | Layout renders briefly, then error page |
| Initial app load | Full-screen "Loading..." | Full-screen "Loading..." (unchanged) |

## Test plan

- [ ] Switch between channels — no blink, layout stays visible
- [ ] Hard refresh — full-screen "Loading..." shows until init, then channel renders
- [ ] Navigate to `/#/000000000000000000000000` — error page appears after brief moment
- [ ] `cd app && npm run types` — no new TypeScript errors