### PR TITLE
fix(docker): resolve arm64 apk failures with deno alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,10 @@ ENV APP_VERSION=$APP_VERSION
 RUN APP_NAME=quack APP_VERSION=$APP_VERSION npm run build
 
 FROM denoland/deno:alpine-2.6.8
-RUN apk -U upgrade
-RUN apk add vips-cpp build-base vips vips-dev
+# WORKAROUND: Deno alpine image ships glibc-linked libs in /usr/local/lib/ that break apk on arm64
+# See: https://github.com/denoland/deno_docker/issues/373 — remove when fixed upstream
+RUN LD_LIBRARY_PATH=/usr/lib apk -U upgrade
+RUN LD_LIBRARY_PATH=/usr/lib apk add vips-cpp build-base vips vips-dev
 ENV ENVIRONMENT=production
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Fix arm64 Docker build failure caused by `denoland/deno:alpine-2.6.8` shipping glibc-linked `libcrypto.so.3` in `/usr/local/lib/`
- Prefix `apk` commands with `LD_LIBRARY_PATH=/usr/lib` to use Alpine's musl-based system libraries instead
- Resolves CI failure on PR #233

## Context
The Deno Alpine Docker image bundles its own `libcrypto.so.3` and `libgcc_s.so.1` compiled against glibc, which conflicts with Alpine's musl libc on arm64. This causes `apk` to fail with "Error relocating" symbol errors (exit code 127).

Known upstream issue: https://github.com/denoland/deno_docker/issues/373

## Test plan
- [ ] Verify arm64 Docker build succeeds in CI
- [ ] Verify amd64 Docker build still works