### PR TITLE
fix(docker): remove deno glibc libs that break apk triggers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ ENV APP_VERSION=$APP_VERSION
 RUN APP_NAME=quack APP_VERSION=$APP_VERSION npm run build
 
 FROM denoland/deno:alpine-2.6.8
-# WORKAROUND: Deno alpine image ships glibc-linked libs in /usr/local/lib/ that break apk on arm64
+# WORKAROUND: Deno alpine image ships glibc-linked libs in /usr/local/lib/ that break
+# apk and post-install triggers. Remove them so system tools use Alpine's musl libs.
 # See: https://github.com/denoland/deno_docker/issues/373 — remove when fixed upstream
-RUN LD_LIBRARY_PATH=/usr/lib apk -U upgrade
-RUN LD_LIBRARY_PATH=/usr/lib apk add vips-cpp build-base vips vips-dev
+RUN rm -f /usr/local/lib/lib*.so*
+RUN apk -U upgrade
+RUN apk add vips-cpp build-base vips vips-dev
 ENV ENVIRONMENT=production
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Replace `LD_LIBRARY_PATH` workaround with removing Deno's glibc-linked libs entirely
- `LD_LIBRARY_PATH=/usr/lib` fixed `apk` itself but post-install triggers (`glib`, `shared-mime-info`, `gdk-pixbuf`) spawn subprocesses that don't inherit it
- Now removes `/usr/local/lib/lib*.so*` before running `apk`, so all system tools use Alpine's musl libs
- Fixes CI failure on PR #233 (both amd64 and arm64)

## Context
Deno Alpine image ships glibc-linked `libz.so.1`, `libcrypto.so.3`, `libgcc_s.so.1` in `/usr/local/lib/` that shadow Alpine's musl-based system libraries. The Deno binary itself is statically linked and doesn't need them.

Upstream issue: https://github.com/denoland/deno_docker/issues/373

## Test plan
- [ ] Verify Docker build succeeds on both amd64 and arm64 in CI
- [ ] Verify Deno still runs correctly after lib removal