### PR TITLE
ci: trigger docker build from release workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - v*
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -73,6 +79,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
 
       - name: Build and push Docker image
         id: push
@@ -85,7 +94,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: |
-            APP_VERSION=${{ github.ref_name }}
+            APP_VERSION=${{ inputs.version || github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.version.outputs.result }}
 
     steps:
       - name: Extract version from labels
@@ -47,3 +49,10 @@ jobs:
             });
 
             core.info(`Created release ${version}`);
+
+  docker:
+    needs: release
+    uses: ./.github/workflows/docker.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
Fix GITHUB_TOKEN limitation: release.yml now calls docker.yml directly via workflow_call.