### PR TITLE
chore(types): remove any types from backend core

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -116,9 +116,12 @@ Create standard story template with:
 
 ### 2.1 Type Safety (HIGH PRIORITY)
 - [ ] Fix pre-existing TypeScript errors (17 errors in base)
-- [ ] Remove `any` types - 20 instances in app/src
+- [x] Remove `any` types from backend core (serializers, bus, command/query, repos, webhooks) — PR #267
+- [ ] Remove `any` types from storage, encryption, config modules
+- [ ] Remove `any` types from API module (`deno/api/`)
+- [ ] Remove `any` types from frontend (models, components, contexts)
+- [ ] Remove `any` types from test files and helpers
 - [ ] Fix `style: any` unused prop in `ActionButton.tsx:10`
-- [ ] Add proper typing to API module (`deno/api/mod.ts` - `payload: any`, `document: any`)
 - [ ] Remove `@ts-ignore` comments in `deno/api/files.ts` (5+ instances)
 - [ ] Standardize Props interface naming
 

--- a/deno/server/core/bus.ts
+++ b/deno/server/core/bus.ts
@@ -1,12 +1,14 @@
 import { EntityId } from "../types.ts";
 import { serialize } from "./serializer.ts";
 
-type Listeners = { [key: string]: ((...args: any[]) => void)[] };
+type BusMessage = Record<string, unknown>;
+type BusCallback = (msg: BusMessage) => void;
+type Listeners = { [key: string]: BusCallback[] };
 
 class Emitter {
   listeners: Listeners = {};
 
-  on = (ev: string, cb: (...args: any[]) => void) => {
+  on = (ev: string, cb: BusCallback) => {
     this.listeners[ev] = this.listeners[ev] ?? [];
     this.listeners[ev].push(cb);
     return () => {
@@ -14,10 +16,10 @@ class Emitter {
     };
   };
 
-  emit = (ev: string, ...args: any[]) => {
+  emit = (ev: string, msg: BusMessage) => {
     (this.listeners[ev] ?? []).forEach((cb) => {
       try {
-        cb(...serialize(args));
+        cb(serialize(msg));
       } catch (e) {
         console.error(e);
       }
@@ -45,7 +47,11 @@ export class Bus {
       {},
     );
 
-  group = (userIds: (EntityId | string)[], msg: any, senderId?: EntityId) => {
+  group = (
+    userIds: (EntityId | string)[],
+    msg: BusMessage,
+    senderId?: EntityId,
+  ) => {
     this.internalBus.emit("notif", {
       ...msg,
       _target: "group",
@@ -57,7 +63,7 @@ export class Bus {
     });
   };
 
-  direct = (userId: EntityId | string, msg: any) => {
+  direct = (userId: EntityId | string, msg: BusMessage) => {
     this.internalBus.emit(userId.toString(), { ...msg, _target: "direct" });
     this.internalBus.emit("notif", {
       ...msg,
@@ -66,12 +72,12 @@ export class Bus {
     });
   };
 
-  broadcast = (msg: any) => {
+  broadcast = (msg: BusMessage) => {
     this.internalBus.emit("all", { ...msg, _target: "broadcast" });
     this.internalBus.emit("notif", { ...msg, _target: "broadcast" });
   };
 
-  on = (userId: EntityId | string, cb: (...args: any[]) => void) => {
+  on = (userId: EntityId | string, cb: BusCallback) => {
     const a = this.internalBus.on(userId.toString(), cb);
     const b = this.internalBus.on("all", cb);
     return () => {
@@ -80,8 +86,8 @@ export class Bus {
     };
   };
 
-  notif = (msg: any) =>
+  notif = (msg: BusMessage) =>
     this.internalBus.emit("notif", { ...msg, _target: "notif" });
 
-  onNotif = (cb: (...args: any[]) => void) => this.internalBus.on("notif", cb);
+  onNotif = (cb: BusCallback) => this.internalBus.on("notif", cb);
 }

--- a/deno/server/core/command.ts
+++ b/deno/server/core/command.ts
@@ -2,26 +2,7 @@ import * as v from "valibot";
 import { EntityId } from "../types.ts";
 import type { Core } from "./core.ts";
 import { AppError } from "./errors.ts";
-
-function recursiveSerialize(obj: unknown): unknown {
-  if (obj instanceof EntityId) {
-    return obj.toString();
-  }
-  if (Array.isArray(obj)) {
-    return obj.map(recursiveSerialize);
-  }
-  if (typeof obj === "object" && obj !== null) {
-    const record = obj as Record<string, unknown>;
-    for (const key in record) {
-      record[key] = recursiveSerialize(record[key]);
-    }
-  }
-  return obj;
-}
-
-function serialize<A>(obj: A): A {
-  return recursiveSerialize(obj) as A;
-}
+import { serialize } from "./serializer.ts";
 
 export type Definition<
   T extends string,

--- a/deno/server/core/command.ts
+++ b/deno/server/core/command.ts
@@ -3,19 +3,24 @@ import { EntityId } from "../types.ts";
 import type { Core } from "./core.ts";
 import { AppError } from "./errors.ts";
 
-function serialize<A>(obj: A): any {
+function recursiveSerialize(obj: unknown): unknown {
   if (obj instanceof EntityId) {
     return obj.toString();
   }
   if (Array.isArray(obj)) {
-    return obj.map(serialize);
+    return obj.map(recursiveSerialize);
   }
-  if (typeof obj === "object") {
-    for (const key in obj) {
-      obj[key] = serialize(obj[key]);
+  if (typeof obj === "object" && obj !== null) {
+    const record = obj as Record<string, unknown>;
+    for (const key in record) {
+      record[key] = recursiveSerialize(record[key]);
     }
   }
   return obj;
+}
+
+function serialize<A>(obj: A): A {
+  return recursiveSerialize(obj) as A;
 }
 
 export type Definition<
@@ -69,10 +74,12 @@ export function createCommand<
     internal() {
       return exec(body, core);
     },
-    then(
-      onfulfilled: (value: void | EntityId | string | null) => any,
-      onrejected: (reason: any) => any,
-    ) {
+    then<TResult1 = void | EntityId | string | null, TResult2 = never>(
+      onfulfilled: (
+        value: void | EntityId | string | null,
+      ) => TResult1 | PromiseLike<TResult1>,
+      onrejected: (reason: unknown) => TResult2 | PromiseLike<TResult2>,
+    ): PromiseLike<TResult1 | TResult2> {
       return exec(body, core).then((r) => serialize(r)).then(
         onfulfilled,
         onrejected,
@@ -94,10 +101,11 @@ export type CommandDirectory<T extends { type: string }[]> = {
 export function buildCommandCollection<T extends { type: string }[]>(
   events: T,
 ): CommandDirectory<T> {
-  return events.reduce((acc, curr) => {
-    acc[curr.type] = curr;
-    return acc;
-  }, {} as any);
+  const result: Record<string, T[number]> = {};
+  for (const curr of events) {
+    result[curr.type] = curr;
+  }
+  return result as CommandDirectory<T>;
 }
 
 export type EventFrom<T> = T extends Command<infer T, infer U>

--- a/deno/server/core/core.ts
+++ b/deno/server/core/core.ts
@@ -125,9 +125,20 @@ export class Core {
     }
   }
 
-  dispatch = (evt: EventFrom<typeof commands[keyof typeof commands]>) => (
-    (commands[evt.type] as any).handler(evt.body, this)
-  );
+  dispatch = (evt: EventFrom<typeof commands[keyof typeof commands]>) => {
+    // Type assertion needed: evt.type and evt.body are correlated through
+    // the discriminated union, but TypeScript can't prove it for indexed access
+    type AnyCommand = typeof commands[keyof typeof commands];
+    const cmd = commands[evt.type] as AnyCommand;
+    // deno-lint-ignore no-explicit-any
+    return (cmd.handler as (
+      body: any,
+      core: Core,
+    ) => ReturnType<AnyCommand["handler"]>)(
+      evt.body,
+      this,
+    );
+  };
 
   close = async () => {
     this.events.dispatch({

--- a/deno/server/core/message/create.ts
+++ b/deno/server/core/message/create.ts
@@ -5,7 +5,7 @@ import { AccessDenied, InvalidMessage, ResourceNotFound } from "../errors.ts";
 import { flatten } from "./flatten.ts";
 import { ChannelType, EntityId } from "../../types.ts";
 
-function filterUndefined(data: any) {
+function filterUndefined(data: Record<string, unknown>) {
   return Object.fromEntries(
     Object.entries(data).filter(([, v]) => v !== undefined),
   );
@@ -79,7 +79,7 @@ export default createCommand({
     userId: msg.userId,
     links: msg.links,
     mentions: msg.mentions,
-    attachments: msg.attachments?.map((file: any) => ({
+    attachments: msg.attachments?.map((file) => ({
       id: file.id,
       fileName: file.fileName,
       contentType: file.contentType,
@@ -104,9 +104,8 @@ export default createCommand({
     type: "channel:join",
     body: {
       channelId: msg.channelId.toString(),
-      userIds: msg.mentions.filter((m: any) =>
-        !channel.users.some((u) => u.eq(m))
-      ).map((u) => u.toString()),
+      userIds: msg.mentions.filter((m) => !channel.users.some((u) => u.eq(m)))
+        .map((u) => u.toString()),
     },
   }).internal();
 

--- a/deno/server/core/query.ts
+++ b/deno/server/core/query.ts
@@ -6,7 +6,7 @@ import { serialize } from "./serializer.ts";
 
 export type Event = {
   type: string;
-  body: any;
+  body: unknown;
 };
 export type Definition = {
   type: string;
@@ -38,7 +38,10 @@ export function createQuery<A extends Definition, B>(
       async internal() {
         return await exec(body);
       },
-      then(onfulfilled: (value: B) => any, onrejected: (reason: any) => any) {
+      then<TResult1 = B, TResult2 = never>(
+        onfulfilled: (value: B) => TResult1 | PromiseLike<TResult1>,
+        onrejected: (reason: unknown) => TResult2 | PromiseLike<TResult2>,
+      ): PromiseLike<TResult1 | TResult2> {
         return exec(body).then((ret) => serialize(ret)).then(
           onfulfilled,
           onrejected,

--- a/deno/server/core/serializer.ts
+++ b/deno/server/core/serializer.ts
@@ -1,16 +1,21 @@
 import { EntityId } from "../types.ts";
 
-export function serialize<A>(obj: A): any {
+function recursiveSerialize(obj: unknown): unknown {
   if (obj instanceof EntityId) {
     return obj.toString();
   }
   if (Array.isArray(obj)) {
-    return obj.map(serialize);
+    return obj.map(recursiveSerialize);
   }
-  if (typeof obj === "object") {
-    for (const key in obj) {
-      obj[key] = serialize(obj[key]);
+  if (typeof obj === "object" && obj !== null) {
+    const record = obj as Record<string, unknown>;
+    for (const key in record) {
+      record[key] = recursiveSerialize(record[key]);
     }
   }
   return obj;
+}
+
+export function serialize<A>(obj: A): A {
+  return recursiveSerialize(obj) as A;
 }

--- a/deno/server/core/webhooks.ts
+++ b/deno/server/core/webhooks.ts
@@ -7,15 +7,15 @@ export class Webhooks {
     this.core.bus.onNotif(this.handleEvent.bind(this));
   }
 
-  async handleEvent(event: any) {
+  async handleEvent(event: Record<string, unknown>) {
     for (const webhook of (this.config?.webhooks ?? [])) {
-      if (!webhook.events || webhook.events.includes(event.type)) {
+      if (!webhook.events || webhook.events.includes(event.type as string)) {
         await this.send(webhook, event);
       }
     }
   }
 
-  async send(webhook: Webhook, event: any) {
+  async send(webhook: Webhook, event: Record<string, unknown>) {
     try {
       const body = JSON.stringify({ type: event.type, event });
       const res = await fetch(webhook.url, {

--- a/deno/server/infra/repo/channelRepo.ts
+++ b/deno/server/infra/repo/channelRepo.ts
@@ -9,7 +9,7 @@ export class ChannelRepo extends Repo<ChannelQuery, Channel> {
   override makeQuery(data: ChannelQuery) {
     const { userId, users, usersCount, ...rest } = serialize(data);
     const query = { ...rest };
-    const userQuery: any = {};
+    const userQuery: Record<string, unknown> = {};
     if (userId) userQuery["$elemMatch"] = { $eq: userId };
     if (users) userQuery["$all"] = users;
     if (usersCount) userQuery["$size"] = usersCount;

--- a/deno/server/infra/repo/serializer.ts
+++ b/deno/server/infra/repo/serializer.ts
@@ -1,7 +1,8 @@
 import { EntityId } from "../../types.ts";
 import { ObjectId } from "./db.ts";
 
-function recursiveDeserialize(obj: any): any {
+// deno-lint-ignore no-explicit-any
+function recursiveDeserialize(obj: unknown): any {
   if (obj instanceof EntityId) {
     return EntityId.from(obj);
   }
@@ -11,41 +12,46 @@ function recursiveDeserialize(obj: any): any {
   if (Array.isArray(obj)) {
     return obj.map(recursiveDeserialize);
   }
-  if (typeof obj === "object") {
-    for (const key in obj) {
-      obj[key] = recursiveDeserialize(obj[key]);
+  if (typeof obj === "object" && obj !== null) {
+    const record = obj as Record<string, unknown>;
+    for (const key in record) {
+      record[key] = recursiveDeserialize(record[key]);
     }
-    if (obj && obj._id) {
-      obj.id = obj._id;
-      delete obj._id;
+    if (record._id) {
+      record.id = record._id;
+      delete record._id;
     }
   }
   return obj;
 }
 
-export function deserialize(data: any) {
+// deno-lint-ignore no-explicit-any
+export function deserialize(data: unknown): any {
   return recursiveDeserialize(data);
 }
 
-function recursiveSerialize(obj: any): any {
+// deno-lint-ignore no-explicit-any
+function recursiveSerialize(obj: unknown): any {
   if (obj instanceof EntityId) {
     return new ObjectId(obj.value);
   }
   if (Array.isArray(obj)) {
     return obj.map(recursiveSerialize);
   }
-  if (typeof obj === "object") {
-    for (const key in obj) {
-      obj[key] = recursiveSerialize(obj[key]);
+  if (typeof obj === "object" && obj !== null) {
+    const record = obj as Record<string, unknown>;
+    for (const key in record) {
+      record[key] = recursiveSerialize(record[key]);
     }
-    if (obj && obj.id) {
-      obj._id = obj.id;
-      delete obj.id;
+    if (record.id) {
+      record._id = record.id;
+      delete record.id;
     }
   }
   return obj;
 }
 
-export function serialize(data: any) {
+// deno-lint-ignore no-explicit-any
+export function serialize(data: unknown): any {
   return recursiveSerialize(data);
 }

--- a/deno/server/infra/repo/userRepo.ts
+++ b/deno/server/infra/repo/userRepo.ts
@@ -23,7 +23,10 @@ export class UserRepo extends Repo<UserQuery, DbUser> {
       );
   }
 
-  async upgrade(query: UserQuery, data: { publicKey: any; secrets: Secret }) {
+  async upgrade(
+    query: UserQuery,
+    data: { publicKey: JsonWebKey; secrets: Secret },
+  ) {
     const { db } = await this.connect();
     await db.collection(this.COLLECTION)
       .updateOne(

--- a/deno/server/inter/cli/mod.ts
+++ b/deno/server/inter/cli/mod.ts
@@ -3,9 +3,15 @@ import { Command } from "@cliffy/command";
 const run = new Command()
   .arguments("<config:string>")
   .description("Runs the chat server.")
-  .action((options: any, source: string, destination?: string) => {
-    console.log("clone command called");
-  });
+  .action(
+    (
+      _options: Record<string, unknown>,
+      source: string,
+      _destination?: string,
+    ) => {
+      console.log("clone command called");
+    },
+  );
 
 await new Command()
   .name("chat")

--- a/deno/server/inter/http/mod.ts
+++ b/deno/server/inter/http/mod.ts
@@ -33,7 +33,7 @@ export class HttpInterface extends Planigale {
       schema.addKeyword({
         keyword: "requireAny",
         type: "object",
-        validate: (keys: string[], data: any) => {
+        validate: (keys: string[], data: Record<string, unknown>) => {
           if (keys.some((key) => key in data)) {
             return true;
           }

--- a/deno/server/inter/http/routes/channel/postChannel.ts
+++ b/deno/server/inter/http/routes/channel/postChannel.ts
@@ -39,7 +39,7 @@ export default (core: Core) =>
         },
       });
       const channel = await core.channel.get({
-        id: channelId,
+        id: channelId!,
         userId: req.state.user.id,
       });
       return Res.json(channel);

--- a/deno/server/inter/http/routes/channel/putDirect.ts
+++ b/deno/server/inter/http/routes/channel/putDirect.ts
@@ -26,7 +26,7 @@ export default (core: Core) =>
         },
       });
       const channel = await core.channel.get({
-        id: channelId,
+        id: channelId!,
         userId: req.state.user.id,
       });
       return Res.json(channel);

--- a/deno/server/inter/http/routes/messages/create.ts
+++ b/deno/server/inter/http/routes/messages/create.ts
@@ -54,7 +54,7 @@ export default (core: Core) =>
         body: { ...req.body, userId, channelId },
       });
 
-      const msg = await core.message.get({ userId, messageId: id });
+      const msg = await core.message.get({ userId, messageId: id! });
       return Response.json(msg);
     },
   });

--- a/deno/server/inter/http/routes/mobile/notifications.ts
+++ b/deno/server/inter/http/routes/mobile/notifications.ts
@@ -42,7 +42,8 @@ export default (core: Core) =>
       }, HEARTBEAT_INTERVAL_MS);
 
       // Subscribe to bus events for this user
-      const off = core.bus.on(userId, async (msg: BusMessage) => {
+      const off = core.bus.on(userId, async (raw) => {
+        const msg = raw as BusMessage;
         // Only process message events for notifications
         if (msg.type !== "message") {
           return;

--- a/deno/server/inter/http/routes/users/create.ts
+++ b/deno/server/inter/http/routes/users/create.ts
@@ -56,7 +56,7 @@ export default (core: Core) =>
           secrets: req.body.secrets,
         },
       });
-      const user: DbUser | null = await core.user.get({ id: createdId });
+      const user: DbUser | null = await core.user.get({ id: createdId! });
       if (!user) {
         throw new InternalServerError(
           new Error("User not created, but no error thrown"),


### PR DESCRIPTION
## Summary

Removes ~25 `any` type annotations from backend core, infra, and inter layers, replacing them with proper types (`unknown`, `Record<string, unknown>`, `BusMessage`, `JsonWebKey`, `PromiseLike` signatures). Part of the ongoing type safety cleanup tracked in BACKLOG.md section 2.1.

## Changes

**Serializers** (`core/serializer.ts`, `infra/repo/serializer.ts`)
- Extract internal `recursiveSerialize`/`recursiveDeserialize` functions with `unknown` params
- Public API preserved for compatibility (infra serializer retains `any` return to satisfy MongoDB driver)

**Event Bus** (`core/bus.ts`)
- Define `BusMessage = Record<string, unknown>` and `BusCallback` types
- Replace all `(...args: any[])` callback signatures with typed alternatives

**Command/Query** (`core/command.ts`, `core/query.ts`)
- Replace `then()` callbacks with proper `PromiseLike<TResult1 | TResult2>` signatures
- Replace `{} as any` in `buildCommandCollection` with typed `Record<string, T[number]>` accumulator
- Change `Event.body: any` to `unknown`

**Core dispatch** (`core/core.ts`)
- Replace `as any` cast with scoped `deno-lint-ignore` and typed handler assertion
- Add non-null assertions in route handlers that consume dispatch results (`postChannel`, `putDirect`, `messages/create`, `users/create`)

**Infrastructure**
- `channelRepo.ts`: `userQuery: any` → `Record<string, unknown>`
- `userRepo.ts`: `publicKey: any` → `JsonWebKey`

**Other**
- `webhooks.ts`: `event: any` → `Record<string, unknown>`
- `http/mod.ts`: `data: any` → `Record<string, unknown>` in schema validator
- `cli/mod.ts`: `options: any` → `Record<string, unknown>`
- `message/create.ts`: `filterUndefined(data: any)` → typed, remove redundant type annotations on `file` and `m` callbacks

## Testing

- `deno task check` passes (fmt + lint + 115 tests)
- All existing integration tests pass unchanged

## Notes

- Infra serializer public API intentionally retains `any` return type — these bridge TypeScript domain types to MongoDB's `Document` type. Proper fix is tracked in BACKLOG 3.8 (Valibot database layer).
- `core.ts` dispatch still requires one `deno-lint-ignore no-explicit-any` for the correlated union dispatch pattern (TypeScript limitation with mapped type indexing).
- First of a planned series of PRs covering storage/encryption, API module, frontend, and test files.