### PR TITLE
chore(types): remove any types from storage, encryption, and support modules

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -116,9 +116,12 @@ Create standard story template with:
 
 ### 2.1 Type Safety (HIGH PRIORITY)
 - [ ] Fix pre-existing TypeScript errors (17 errors in base)
-- [ ] Remove `any` types - 20 instances in app/src
+- [x] Remove `any` types from backend core (serializers, bus, command/query, repos, HTTP/CLI) — PR #272
+- [x] Remove `any` types from storage, encryption, config, migrate, tools modules
+- [ ] Remove `any` types from API module (`deno/api/`) — ~30 instances
+- [ ] Remove `any` types from frontend (`app/src/`) — ~20 instances
+- [ ] Remove `any` types from test files — ~98 instances across 19 files
 - [ ] Fix `style: any` unused prop in `ActionButton.tsx:10`
-- [ ] Add proper typing to API module (`deno/api/mod.ts` - `payload: any`, `document: any`)
 - [ ] Remove `@ts-ignore` comments in `deno/api/files.ts` (5+ instances)
 - [ ] Standardize Props interface naming
 
@@ -288,7 +291,7 @@ Create standard story template with:
 ## Notes
 
 - Created: 2026-02-06
-- Last updated: 2026-02-08
+- Last updated: 2026-02-09
 - Progress:
   - ✅ **Section 1: Storybook Cleanup - COMPLETE**
     - PR #249: Config fixes
@@ -299,6 +302,8 @@ Create standard story template with:
     - PR #254: Message story image fix
   - 🔄 **Section 2: Code Cleanup - IN PROGRESS**
     - PR #255: Dependency updates (npm packages, @std alignment, ESLint React version)
+    - PR #272: Remove `any` types from backend core
+    - PR #273: Remove `any` types from storage, encryption, config, migrate, tools
   - 🔄 **Section 3: Architecture Refactoring - IN PROGRESS**
     - ✅ 3.7 Documentation: ARCHITECTURE.md, CONVENTIONS.md, 14 ADRs, CLAUDE.md
       - PR #256: Architecture docs

--- a/deno/config/types.ts
+++ b/deno/config/types.ts
@@ -8,7 +8,7 @@ export type Config = {
   port: number;
   databaseUrl: string;
   cors: (string | RegExp)[];
-  plugins?: ((app: any, core: any) => Promise<any> | any)[];
+  plugins?: ((app: unknown, core: unknown) => Promise<void> | void)[];
   webhooks?: {
     url: string;
     events?: string[];

--- a/deno/encryption/mod.ts
+++ b/deno/encryption/mod.ts
@@ -36,7 +36,7 @@ export function encryptor(jwk: JsonWebKey) {
   ]);
 
   return {
-    encrypt: async (message: any) => {
+    encrypt: async (message: unknown) => {
       const iv = crypto.getRandomValues(new Uint8Array(12)); // GCM uses 12 bytes IV
       const encoded = new TextEncoder().encode(JSON.stringify(message));
       const keyy = await key;
@@ -70,7 +70,7 @@ export function encryptor(jwk: JsonWebKey) {
   };
 }
 export async function encrypt(
-  message: any,
+  message: unknown,
   encryptionKey: JsonWebKey | CryptoKey,
 ) {
   const key = importKey(encryptionKey);
@@ -88,7 +88,7 @@ export async function encrypt(
   };
 }
 
-export async function decrypt<T = any>(
+export async function decrypt<T = unknown>(
   data: { encrypted: string; _iv: string },
   encryptionKey: JsonWebKey | CryptoKey,
 ): Promise<T> {
@@ -291,7 +291,7 @@ export async function prepareRegistration(
   };
 }
 
-export async function decryptSessionSecrets<T = any>(
+export async function decryptSessionSecrets<T = unknown>(
   email: string,
   password: string,
   secrets: EncryptedData,

--- a/deno/migrate/mod.ts
+++ b/deno/migrate/mod.ts
@@ -13,7 +13,7 @@ export class Database {
 
   databaseUrl: string;
 
-  promises: Promise<any>[] = [];
+  promises: Promise<unknown>[] = [];
 
   connected = false;
 

--- a/deno/server/app.ts
+++ b/deno/server/app.ts
@@ -7,9 +7,7 @@ const core = new Core({
 });
 const http = new HttpInterface(core);
 await Promise.all(
-  config.plugins?.map((
-    plugin: (app: HttpInterface, core: Core) => Promise<any> | any,
-  ) => plugin(http, core)) ?? [],
+  config.plugins?.map((plugin) => plugin(http, core)) ?? [],
 );
 
 http.onClose(async () => {

--- a/deno/storage/src/core/mod.ts
+++ b/deno/storage/src/core/mod.ts
@@ -10,8 +10,18 @@ type ScalingOpts = {
   height?: number;
 };
 
+interface FileService {
+  upload(
+    stream: ReadableStream<Uint8Array>,
+    options: FileOpts,
+  ): Promise<string>;
+  get(id: string): Promise<FileData>;
+  remove(id: string): Promise<void>;
+  exists(id: string): Promise<boolean>;
+}
+
 class Files {
-  _sharp: any;
+  _sharp: typeof sharp | null | undefined = undefined;
   async getSharp() {
     if (this._sharp === undefined) {
       try {
@@ -28,7 +38,7 @@ class Files {
   static getFileId = (id: string, width = 0, height = 0) =>
     `${id}-${width}x${height}`;
 
-  private service: any;
+  private service!: FileService;
 
   constructor(config: Config) {
     this.init(config.storage);

--- a/deno/storage/src/core/streams.ts
+++ b/deno/storage/src/core/streams.ts
@@ -1,43 +1,34 @@
 import { Readable } from "node:stream";
 
-interface ListenerInterface {
-  data: (chunk: any) => void;
-  end: (chunk: any) => void;
-  close: (err: any) => void;
-  error: (err: any) => void;
-}
-
 export function toWebStream(nodeStream: Readable) {
   let destroyed = false;
-  const listeners = {} as ListenerInterface;
+  // deno-lint-ignore no-explicit-any
+  const listeners: Record<string, (...args: any[]) => void> = {};
 
-  function start(controller: any) {
+  function start(controller: ReadableStreamDefaultController<Uint8Array>) {
     listeners.data = onData;
     listeners.end = onData;
     listeners.end = onDestroy;
     listeners.close = onDestroy;
     listeners.error = onDestroy;
     for (const name in listeners) {
-      nodeStream.on(name, listeners[name as keyof ListenerInterface]);
+      nodeStream.on(name, listeners[name]);
     }
 
     nodeStream.pause();
 
-    function onData(chunk: any) {
+    function onData(chunk: Uint8Array) {
       if (destroyed) return;
       controller.enqueue(new Uint8Array(chunk));
       nodeStream.pause();
     }
 
-    function onDestroy(err: any) {
+    function onDestroy(err?: Error) {
       if (destroyed) return;
       destroyed = true;
 
       for (const name in listeners) {
-        nodeStream.removeListener(
-          name,
-          listeners[name as keyof ListenerInterface],
-        );
+        nodeStream.removeListener(name, listeners[name]);
       }
 
       if (err) controller.error(err);
@@ -54,10 +45,7 @@ export function toWebStream(nodeStream: Readable) {
     destroyed = true;
 
     for (const name in listeners) {
-      nodeStream.removeListener(
-        name,
-        listeners[name as keyof ListenerInterface],
-      );
+      nodeStream.removeListener(name, listeners[name]);
     }
 
     nodeStream.push(null);
@@ -75,7 +63,7 @@ class NodeReadable extends Readable {
 
   private reader: ReadableStreamDefaultReader<Uint8Array>;
 
-  private pendingRead?: Promise<any>;
+  private pendingRead?: Promise<ReadableStreamReadResult<Uint8Array>>;
 
   constructor(stream: ReadableStream) {
     super();

--- a/deno/tools/cache.ts
+++ b/deno/tools/cache.ts
@@ -1,6 +1,6 @@
 import { mergeRanges, Range } from "./range.ts";
 
-export class CacheEntry<T extends any[]> extends Range {
+export class CacheEntry<T extends unknown[]> extends Range {
   data: T;
   timestamp: number;
 
@@ -10,7 +10,7 @@ export class CacheEntry<T extends any[]> extends Range {
     this.timestamp = new Date().getTime();
   }
 
-  static sort(repo: CacheEntry<any>[]) {
+  static sort(repo: CacheEntry<unknown[]>[]) {
     return [...repo].sort((a, b) => a.from - b.from);
   }
 
@@ -24,7 +24,7 @@ export type CacheQuery = {
   to?: number;
 };
 
-export class Cache<T extends any[]> {
+export class Cache<T extends unknown[]> {
   repo: CacheEntry<T>[] = [];
 
   merge = (a: CacheEntry<T>, b: CacheEntry<T>): CacheEntry<T> => (


### PR DESCRIPTION
## Summary

Remove `any` types from storage, encryption, config, migration, and utility modules. This is part 2 of the ongoing type safety cleanup (follows PR #272 which covered backend core).

## Changes

- **`deno/storage/src/core/mod.ts`** — Added explicit `FileService` interface, typed `_sharp` as `typeof sharp | null | undefined`, changed `service` from `any` to `FileService`
- **`deno/storage/src/core/streams.ts`** — Typed `ReadableStreamDefaultController<Uint8Array>`, `Uint8Array` for data chunks, `Error` for error params; simplified listener record (one justified `deno-lint-ignore` for incompatible callback signatures in same record)
- **`deno/encryption/mod.ts`** — Changed `message: any` to `unknown` in encrypt functions, generic defaults `T = any` to `T = unknown` in decrypt functions
- **`deno/config/types.ts`** — Plugin type from `(app: any, core: any) => Promise<any> | any` to `(app: unknown, core: unknown) => Promise<void> | void`
- **`deno/server/app.ts`** — Removed redundant explicit plugin type annotation (now inferred from config)
- **`deno/migrate/mod.ts`** — `Promise<any>[]` to `Promise<unknown>[]`
- **`deno/tools/cache.ts`** — `T extends any[]` to `T extends unknown[]`, `CacheEntry<any>[]` to `CacheEntry<unknown[]>[]`
- **`BACKLOG.md`** — Updated type safety tracking for completed PRs

## Testing

- `deno task check` passes (fmt + lint + 115 tests)