### PR TITLE
chore(types): remove any types from API module (#274)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -116,9 +116,10 @@ Create standard story template with:
 
 ### 2.1 Type Safety (HIGH PRIORITY)
 - [ ] Fix pre-existing TypeScript errors (17 errors in base)
-- [ ] Remove `any` types - 20 instances in app/src
+- [x] Remove `any` types from API module (`deno/api/`) — ApiError, callApi, fetchWithCredentials, files, messageTypes
+- [ ] Remove `any` types from frontend (`app/src/`) — ~20 instances
+- [ ] Remove `any` types from test files — ~98 instances across 19 files
 - [ ] Fix `style: any` unused prop in `ActionButton.tsx:10`
-- [ ] Add proper typing to API module (`deno/api/mod.ts` - `payload: any`, `document: any`)
 - [ ] Remove `@ts-ignore` comments in `deno/api/files.ts` (5+ instances)
 - [ ] Standardize Props interface naming
 
@@ -288,7 +289,7 @@ Create standard story template with:
 ## Notes
 
 - Created: 2026-02-06
-- Last updated: 2026-02-08
+- Last updated: 2026-02-09
 - Progress:
   - ✅ **Section 1: Storybook Cleanup - COMPLETE**
     - PR #249: Config fixes
@@ -299,6 +300,9 @@ Create standard story template with:
     - PR #254: Message story image fix
   - 🔄 **Section 2: Code Cleanup - IN PROGRESS**
     - PR #255: Dependency updates (npm packages, @std alignment, ESLint React version)
+    - PR #272: Remove `any` types from backend core
+    - PR #273: Remove `any` types from storage, encryption, config, migrate, tools
+    - PR #274: Remove `any` types from API module
   - 🔄 **Section 3: Architecture Refactoring - IN PROGRESS**
     - ✅ 3.7 Documentation: ARCHITECTURE.md, CONVENTIONS.md, 14 ADRs, CLAUDE.md
       - PR #256: Architecture docs

--- a/deno/api/auth.ts
+++ b/deno/api/auth.ts
@@ -8,10 +8,15 @@ import * as enc from "@quack/encryption";
 import type API from "./mod.ts";
 
 export class ApiError extends Error {
-  payload: any;
+  payload: Record<string, unknown>;
   url: string;
   status: number;
-  constructor(msg: string, status: number, url: string, payload: any) {
+  constructor(
+    msg: string,
+    status: number,
+    url: string,
+    payload: Record<string, unknown>,
+  ) {
     super(msg);
     this.status = status;
     this.url = url;

--- a/deno/api/files.ts
+++ b/deno/api/files.ts
@@ -55,12 +55,12 @@ export class FilesAPI {
         delete this.aborts[args.clientId];
         resolve(data);
       }, { once: true });
-      xhr.upload.addEventListener("progress", (e: any) => {
+      xhr.upload.addEventListener("progress", (e: ProgressEvent) => {
         if (e.lengthComputable) {
           args.onProgress?.((e.loaded / e.total) * 100);
         }
       });
-      xhr.addEventListener("error", (e: any) => {
+      xhr.addEventListener("error", (e: Event) => {
         delete this.aborts[args.clientId];
         reject(e);
       }, { once: true });
@@ -120,7 +120,7 @@ export class FilesAPI {
     return new Promise((resolve, reject) => {
       (async () => {
         try {
-          const chunks: any[] = [];
+          const chunks: BlobPart[] = [];
           // @ts-ignore This is only for browsers
           for await (const chunk of stream) {
             chunks.push(chunk.value);

--- a/deno/api/messageTypes.ts
+++ b/deno/api/messageTypes.ts
@@ -22,7 +22,7 @@ export type MessageBodyButton = {
   button: string;
   _action: string;
   _style: string;
-  _payload: any;
+  _payload: Record<string, unknown>;
 };
 export type MessageBodyWrap = { wrap: MessageBody };
 export type MessageBodyColumn = { column: MessageBody; _width: number };
@@ -101,7 +101,7 @@ export type MessageData = {
     favicons: string[];
     charset: string;
   }[];
-  parsingErrors?: any[];
+  parsingErrors?: Array<{ message: string; path?: string }>;
   attachments?: Array<{ // TODO make this a separate entity
     id: string;
     fileName: string;

--- a/deno/api/mod.ts
+++ b/deno/api/mod.ts
@@ -15,7 +15,16 @@ import { FilesAPI } from "./files.ts";
 
 export * from "./types.ts";
 
-declare const document: any;
+export type ApiResponse = {
+  type: "response";
+  status: "ok";
+  seqId?: string;
+  data: Record<string, unknown>[];
+};
+
+declare const document: {
+  addEventListener: (type: string, listener: () => void) => void;
+} | undefined;
 
 const isDeno = typeof window === "undefined";
 
@@ -36,10 +45,15 @@ async function waitBeforeRetry(retry: number) {
 }
 
 export class ApiError extends Error {
-  payload: any;
+  payload: Record<string, unknown>;
   url: string;
   status: number;
-  constructor(msg: string, status: number, url: string, payload: any) {
+  constructor(
+    msg: string,
+    status: number,
+    url: string,
+    payload: Record<string, unknown>,
+  ) {
     super(msg);
     this.status = status;
     this.url = url;
@@ -50,7 +64,7 @@ export class ApiError extends Error {
 class API extends EventTarget {
   baseUrl: string;
 
-  _http: any;
+  _http: unknown;
   _token: string | undefined;
 
   userId: string | undefined;
@@ -76,7 +90,7 @@ class API extends EventTarget {
 
   reconnectTimeout: number | undefined;
 
-  set token(value: any) {
+  set token(value: string | undefined) {
     if (typeof value === "string" && value.trim() !== "") {
       this._token = value;
       this.tokenInit();
@@ -183,7 +197,7 @@ class API extends EventTarget {
   async fetchWithCredentials(
     url: string,
     opts: RequestInit = {},
-  ): Promise<any> {
+  ): Promise<Response> {
     return await this.fetch(
       `${this.baseUrl}${url}`,
       this.token
@@ -211,11 +225,11 @@ class API extends EventTarget {
     url: string,
     opts: {
       seqId?: string;
-      mapFn?: (i: any) => any;
+      mapFn?: (i: Record<string, unknown>) => Record<string, unknown>;
       retry?: number;
       retries?: number;
     } & RequestInit = {},
-  ): Promise<any> {
+  ): Promise<ApiResponse | ApiErrorResponse> {
     const retries = opts?.retries ?? 5;
     const retry = opts?.retry ?? 0;
     const res = await this.fetchWithCredentials(url, opts);
@@ -333,7 +347,7 @@ class API extends EventTarget {
       ...Object.fromEntries(
         Object.entries(query).filter(([_, v]) => typeof v !== "undefined"),
       ),
-    } as any);
+    } as Record<string, string>);
     return await this.getResource(
       `/api/channels/${channelId}/messages?${params.toString()}`,
     );
@@ -439,7 +453,7 @@ class API extends EventTarget {
       appId?: string;
       clientId: string;
       action: string;
-      payload: any;
+      payload?: Record<string, unknown>;
     },
   ): Promise<void> {
     const res = await this.fetchWithCredentials(`/api/interactions`, {
@@ -449,7 +463,7 @@ class API extends EventTarget {
     await res.body?.cancel();
   }
 
-  async sendMessage(msg: Partial<Message>): Promise<any> {
+  async sendMessage(msg: Partial<Message>): Promise<Record<string, unknown>> {
     return await new Promise((resolve, reject) => {
       const data = { ...msg };
       let timeoutId: number | null = setTimeout(() => {
@@ -489,7 +503,7 @@ class API extends EventTarget {
     });
   }
 
-  async sendCommand(cmd: Partial<Command>): Promise<any> {
+  async sendCommand(cmd: Partial<Command>): Promise<Record<string, unknown>> {
     const data = { ...cmd };
     const res = await this.fetchWithCredentials(
       "/api/commands/execute",
@@ -521,13 +535,13 @@ class API extends EventTarget {
       case "channels:load": {
         return this.callApi("/api/channels", {
           seqId: msg.seqId,
-          mapFn: (i: any) => ({ type: "channel", ...i }),
+          mapFn: (i: Record<string, unknown>) => ({ type: "channel", ...i }),
         });
       }
       case "user:getAll": {
         return this.callApi("/api/users", {
           seqId: msg.seqId,
-          mapFn: (i: any) => ({ type: "user", ...i }),
+          mapFn: (i: Record<string, unknown>) => ({ type: "user", ...i }),
         });
       }
       case "user:get": {
@@ -536,7 +550,7 @@ class API extends EventTarget {
       case "emoji:getAll": {
         return this.callApi("/api/emojis", {
           seqId: msg.seqId,
-          mapFn: (i: any) => ({ type: "emoji", ...i }),
+          mapFn: (i: Record<string, unknown>) => ({ type: "emoji", ...i }),
         });
       }
       case "channel:create": {
@@ -565,6 +579,7 @@ class API extends EventTarget {
           },
         );
 
+        if (createRes instanceof ApiErrorResponse) return createRes;
         return await this.callApi(`/api/messages/${createRes.data[0].id}`, {
           method: "GET",
         });
@@ -599,19 +614,19 @@ class API extends EventTarget {
           `/api/channels/${msg.channelId}/messages?q=${msg.text}`,
           {
             seqId: msg.seqId,
-            mapFn: (i: any) => ({ type: "search", ...i }),
+            mapFn: (i: Record<string, unknown>) => ({ type: "search", ...i }),
           },
         );
       case "readReceipt:getOwn": {
         return this.callApi("/api/read-receipts", {
           seqId: msg.seqId,
-          mapFn: (i: any) => ({ type: "badge", ...i }),
+          mapFn: (i: Record<string, unknown>) => ({ type: "badge", ...i }),
         });
       }
       case "readReceipt:getChannel": {
         return this.callApi(`/api/channels/${msg.channelId}/read-receipts`, {
           seqId: msg.seqId,
-          mapFn: (i: any) => ({ type: "badge", ...i }),
+          mapFn: (i: Record<string, unknown>) => ({ type: "badge", ...i }),
         });
       }
       case "readReceipt:update": {


### PR DESCRIPTION
## Summary

Remove `any` types from the shared API client module (`deno/api/`). This is part 3 of the type safety cleanup, following PR #272 (backend core) and PR #273 (storage/encryption/support).

## Changes

- **`deno/api/mod.ts`**
  - Added `ApiResponse` type for `callApi` return value (replaces `Promise<any>`)
  - `ApiError.payload: any` → `Record<string, unknown>`
  - `document` declaration: `any` → minimal typed interface (only `addEventListener` is used)
  - `_http: any` → `unknown`
  - `set token(value: any)` → `string | undefined`
  - `fetchWithCredentials` return: `Promise<any>` → `Promise<Response>`
  - `callApi` return: `Promise<any>` → `Promise<ApiResponse | ApiErrorResponse>`
  - `mapFn` callback: `(i: any) => any` → `(i: Record<string, unknown>) => Record<string, unknown>`
  - `postInteraction` payload: `any` → `Record<string, unknown>`
  - `sendMessage` / `sendCommand` return: `Promise<any>` → `Promise<Record<string, unknown>>`
  - `getMessages` URLSearchParams: `as any` → `as Record<string, string>`
  - Added type narrowing for `createRes` in `message:create` dispatch

- **`deno/api/auth.ts`** — Same `ApiError` payload typing

- **`deno/api/files.ts`** — Typed XHR event params (`ProgressEvent`, `Event`), `chunks: any[]` → `BlobPart[]`

- **`deno/api/messageTypes.ts`** — `_payload: any` → `Record<string, unknown>`, `parsingErrors?: any[]` → typed array

- **`BACKLOG.md`** — Updated type safety tracking

## Intentionally unchanged

- `request()` / `req()` methods (untyped message dispatch — deferred to API refactoring, backlog 3.1)
- `Result<T = any, E = any>` generic defaults in `types.ts`
- `T extends any[]` in conditional type utilities
- `getResource<T = any>` generic default

## Testing

- `deno task check` passes (fmt + lint + 115 tests)
- `npm run types` shows only pre-existing errors (16), no new errors introduced