### PR TITLE
chore(types): remove any types from frontend code

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -115,11 +115,13 @@ Create standard story template with:
 ## 2. Code Cleanup
 
 ### 2.1 Type Safety (HIGH PRIORITY)
-- [ ] Fix pre-existing TypeScript errors (17 errors in base)
-- [ ] Remove `any` types - 20 instances in app/src
-- [ ] Fix `style: any` unused prop in `ActionButton.tsx:10`
-- [ ] Add proper typing to API module (`deno/api/mod.ts` - `payload: any`, `document: any`)
-- [ ] Remove `@ts-ignore` comments in `deno/api/files.ts` (5+ instances)
+- [ ] Fix pre-existing TypeScript errors (16 errors in base)
+- [x] Remove `any` types from backend core — serializers, bus, command/query, infra (PR #272)
+- [x] Remove `any` types from storage, encryption, config, migrate, tools (PR #273)
+- [x] Remove `any` types from API module — `ApiError.payload`, `callApi`, `mapFn`, files, messageTypes (PR #274)
+- [x] Remove `any` types from frontend — client, plugins, utils, models, components (PR #275)
+- [ ] Remove `any` types from test files (~98 instances across 19 files)
+- [x] Fix `style: any` prop in `ActionButton.tsx` — typed as `string` (PR #275)
 - [ ] Standardize Props interface naming
 
 ### 2.2 Dead Code & Unused Exports
@@ -288,7 +290,7 @@ Create standard story template with:
 ## Notes
 
 - Created: 2026-02-06
-- Last updated: 2026-02-08
+- Last updated: 2026-02-09
 - Progress:
   - ✅ **Section 1: Storybook Cleanup - COMPLETE**
     - PR #249: Config fixes

--- a/app/src/js/components/contexts/tooltip.tsx
+++ b/app/src/js/components/contexts/tooltip.tsx
@@ -7,7 +7,7 @@ export type TooltipContextType = {
     content: React.ReactNode,
     parent: React.ReactNode | HTMLElement,
   ) => void;
-  hide: (p: any) => void;
+  hide: (p: React.ReactNode | HTMLElement) => void;
 };
 
 export const TooltipContext = createContext<TooltipContextType | undefined>(
@@ -67,7 +67,7 @@ export const TooltipProvider = ({ children }: TooltipContextProps) => {
     [setContent, setPos, setParent],
   );
 
-  const hide = useCallback((p: any) => {
+  const hide = useCallback((p: React.ReactNode | HTMLElement) => {
     if (parent === p) {
       setParent(null);
     }

--- a/app/src/js/components/molecules/ActionButton.tsx
+++ b/app/src/js/components/molecules/ActionButton.tsx
@@ -7,8 +7,8 @@ import { observer } from "mobx-react-lite";
 type ActionButtonProps = {
   children: React.ReactNode;
   action: string;
-  style: any;
-  payload: any;
+  style?: string;
+  payload?: Record<string, unknown>;
 };
 
 export const ActionButton = observer(

--- a/app/src/js/components/molecules/NavChannels.tsx
+++ b/app/src/js/components/molecules/NavChannels.tsx
@@ -76,7 +76,7 @@ export const NavChannels = observer(({ icon }: NavChannelsProps) => {
           className={{ active: id === c.id }}
           key={c.id}
           icon={icon ?? "hash"}
-          badge={badges.getForChannel(c.id as any)}
+          badge={badges.getForChannel(String(c.id))}
           onClick={() => {
             if (isMobile()) {
               hideSidebar();

--- a/app/src/js/components/molecules/NavUsers.tsx
+++ b/app/src/js/components/molecules/NavUsers.tsx
@@ -118,7 +118,7 @@ export const NavUserButton = ({
 const NavUserContainer = observer(
   ({ user, badges }: { user: User; badges: ReadReceiptsModel }) => {
     const app = useApp();
-    const channel = app.channels.getDirect(user.id as any);
+    const channel = app.channels.getDirect(String(user.id));
     let navigate = (_path: string) => {};
     try {
       navigate = useNavigate();
@@ -128,11 +128,11 @@ const NavUserContainer = observer(
     return (
       <NavUserButton
         size={30}
-        user={user as any}
+        user={user as unknown as NavUserButtonProps["user"]}
         className={{ active: id === channel?.id }}
-        badge={badges.getForChannel(channel?.id as any)}
+        badge={badges.getForChannel(channel?.id ? String(channel.id) : "")}
         onClick={async () => {
-          const channel = await client.api.putDirectChannel(user.id as any);
+          const channel = await client.api.putDirectChannel(String(user.id));
           if (isMobile()) {
             hideSidebar();
           }
@@ -152,7 +152,7 @@ export const NavUsers = observer(() => {
       <SectionHeader title="users" />
       {users && users.map((user) => (
         <NavUserContainer
-          key={user.id as any}
+          key={String(user.id)}
           user={user}
           badges={app.readReceipts}
         />

--- a/app/src/js/components/molecules/UserMention.tsx
+++ b/app/src/js/components/molecules/UserMention.tsx
@@ -26,7 +26,7 @@ export const UserMentionBase = observer(({ user }: UserMentionBaseProps) => {
       data-id={user.id}
       href="#"
     >
-      <span className="name">@{user?.name || (user.id as any)}</span>
+      <span className="name">@{user?.name || String(user.id)}</span>
     </StyledLink>
   );
 });

--- a/app/src/js/components/organisms/Search.tsx
+++ b/app/src/js/components/organisms/Search.tsx
@@ -143,7 +143,7 @@ export const SearchResults = observer(
         <div key="bottom" id="scroll-stop" />
         <MessageList
           renderer={BaseRenderer}
-          model={threadModelWrapper as any}
+          model={threadModelWrapper as unknown as import("../../core/models/thread").ThreadModel}
           onMessageClicked={(msg: MessageModel) => {
             gotoMessage(msg);
           }}

--- a/app/src/js/components/pages/ErrorPage.tsx
+++ b/app/src/js/components/pages/ErrorPage.tsx
@@ -66,7 +66,7 @@ const Container = styled.div`
 
 type ErrorPageProps = {
   title?: string;
-  debug?: any;
+  debug?: Record<string, unknown>;
   buttons?: ("retry" | "back" | "home")[];
   description?: string | string[];
 };

--- a/app/src/js/components/pages/Register.tsx
+++ b/app/src/js/components/pages/Register.tsx
@@ -57,8 +57,9 @@ export const Register = () => {
           console.log(err);
           setMsg(err.message);
         } else {
-          if ((err as any)?.errorCode === "USER_ALREADY_EXISTS") {
-            setMsg((err as any).message);
+          const errObj = err as { errorCode?: string; message?: string };
+          if (errObj.errorCode === "USER_ALREADY_EXISTS") {
+            setMsg(errObj.message ?? "User already exists");
           } else {
             console.log(err);
             setMsg("Unknown error");

--- a/app/src/js/core/client.ts
+++ b/app/src/js/core/client.ts
@@ -20,6 +20,7 @@ export class Client {
     return this.api.req(...args);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   on(name: string, cb: (e: any) => void) {
     this.api.on(name, (ev: Event) => {
       if (ev instanceof CustomEvent) {
@@ -32,6 +33,7 @@ export class Client {
     return this;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   on2(name: string, cb: (e: any) => void) {
     const handler = (ev: Event) => {
       if (ev instanceof CustomEvent) {
@@ -45,7 +47,7 @@ export class Client {
     return () => this.api.off(name, handler);
   }
 
-  emit(type: string, data: any) {
+  emit(type: string, data: unknown) {
     return this.api.emit(new CustomEvent(type, { detail: data }));
   }
 }

--- a/app/src/js/core/models/files.ts
+++ b/app/src/js/core/models/files.ts
@@ -39,7 +39,7 @@ export class FileModel {
   async dispose() {
     this.id = undefined;
     this.clientId = "";
-    this.stream = null as any;
+    this.stream = null as unknown as ReadableStream;
     this.status = "pending";
     this.fileSize = 0;
     this.fileName = "";
@@ -144,7 +144,7 @@ export class FilesModel {
       local.patch({ status: "error", progress: 0, error: "unknown error" });
     }
   });
-  toJSON(): any {
+  toJSON(): Array<{ id?: string; clientId: string; fileName: string; fileSize: number; contentType: string }> {
     return this.list.map((f) => ({
       id: f.id,
       clientId: f.clientId,

--- a/app/src/js/core/models/input.ts
+++ b/app/src/js/core/models/input.ts
@@ -43,6 +43,7 @@ export class InputModel {
   }
 
   send = flow(function* (this: InputModel, html: HTMLElement) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const payload: any = fromDom(html);
     html.innerHTML = "";
     payload.attachments = this.files.toJSON();

--- a/app/src/js/core/models/message.ts
+++ b/app/src/js/core/models/message.ts
@@ -49,7 +49,7 @@ export class MessageModel implements ViewMessage {
     favicons: string[];
     charset: string;
   }[];
-  parsingErrors?: Array<{ message: string; path?: string }>;
+  parsingErrors?: Array<{ message: string; nodeAttributes?: Record<string, string | null>; nodeName?: string }>;
   attachments?: Array<{
     id: string;
     fileName: string;

--- a/app/src/js/core/models/message.ts
+++ b/app/src/js/core/models/message.ts
@@ -49,7 +49,7 @@ export class MessageModel implements ViewMessage {
     favicons: string[];
     charset: string;
   }[];
-  parsingErrors?: any[];
+  parsingErrors?: Array<{ message: string; path?: string }>;
   attachments?: Array<{
     id: string;
     fileName: string;

--- a/app/src/js/core/plugins.ts
+++ b/app/src/js/core/plugins.ts
@@ -2,13 +2,13 @@ import { client } from "./client.ts";
 
 declare global {
   interface Window {
-    Chat: any;
+    Chat: typeof plugins;
   }
 }
 
-const registry: Record<string, Array<any>> = {};
+const registry: Record<string, Array<unknown>> = {};
 const plugins = {
-  register: (slot: string, data: any) => {
+  register: (slot: string, data: unknown) => {
     if (typeof data === "function") {
       data = data(client);
     }
@@ -16,7 +16,7 @@ const plugins = {
     [data].flat().forEach((d) => registry[slot].push(d));
   },
 
-  get: (slot: string): any => registry[slot] || [],
+  get: (slot: string): unknown[] => registry[slot] || [],
 };
 
 window.Chat = plugins;

--- a/app/src/js/utils.ts
+++ b/app/src/js/utils.ts
@@ -32,7 +32,7 @@ export const cn = (...classes: ClassNames[]) =>
     return item;
   }).flat().filter(Boolean).join(" ");
 
-export const same = (o1: any, o2: any, fields: string[]): boolean => {
+export const same = (o1: Record<string, unknown>, o2: Record<string, unknown>, fields: string[]): boolean => {
   return fields.every((field) => {
     return o1 && o2 && o1[field] === o2[field];
   });


### PR DESCRIPTION
## Summary

Remove `any` type annotations from frontend source code, replacing them with proper TypeScript types. Part of the ongoing type safety initiative (follows PRs #272, #273, #274 for backend, storage, and API modules).

## Changes

**Core modules:**
- `client.ts` — Add `eslint-disable` comments for justified `any` usage in SSE event callbacks (`on`/`on2`), type `emit` data as `unknown`
- `plugins.ts` — Replace `any` with `typeof plugins`, `unknown`, and `unknown[]`
- `utils.ts` — Type `same()` params as `Record<string, unknown>`

**Models:**
- `files.ts` — Replace `null as any` with `null as unknown as ReadableStream`, add typed `toJSON()` return
- `message.ts` — Type `parsingErrors` array with `{ message: string; path?: string }`
- `input.ts` — Add `eslint-disable` for justified `any` (dynamic `fromDom` payload mutations)

**Components:**
- `tooltip.tsx` — Type tooltip position param as `React.ReactNode | HTMLElement`
- `ActionButton.tsx` — Type `style` as `string`, `payload` as `Record<string, unknown>`
- `NavChannels.tsx` — Replace `as any` with `String()` for EntityId conversion
- `NavUsers.tsx` — Replace 5 `as any` casts with `String()` and `as unknown as NavUserButtonProps["user"]`
- `UserMention.tsx` — Replace `as any` with `String()`
- `Search.tsx` — Replace `as any` with `as unknown as ThreadModel`
- `Register.tsx` — Type error assertion as `{ errorCode?: string; message?: string }`
- `ErrorPage.tsx` — Type `debug` prop as `Record<string, unknown>`

## Testing

- `deno task check` — 115 backend tests pass
- `npm run types` — 16 errors (matches baseline, no regressions)
- `npm run build` — production build succeeds