### PR TITLE
chore(types): remove any types from test files

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -115,10 +115,15 @@ Create standard story template with:
 ## 2. Code Cleanup
 
 ### 2.1 Type Safety (HIGH PRIORITY)
-- [ ] Fix pre-existing TypeScript errors (17 errors in base)
-- [ ] Remove `any` types - 20 instances in app/src
-- [ ] Fix `style: any` unused prop in `ActionButton.tsx:10`
-- [ ] Add proper typing to API module (`deno/api/mod.ts` - `payload: any`, `document: any`)
+- [ ] Fix pre-existing TypeScript errors (16 errors in base)
+- [x] Remove `any` types — ~120 instances across 50+ files replaced with proper types
+  - PR #272: Backend core (serializers, bus, command/query, infra)
+  - PR #273: Storage & encryption modules
+  - PR #274: API module (error types, callApi, method returns, files, messageTypes)
+  - PR #275: Frontend (client, plugins, utils, models, components)
+  - PR #276: Test files (chat.ts helper, 14 test files, users.ts)
+- [x] Fix `style: any` prop in `ActionButton.tsx` → `style?: string` (PR #275)
+- [x] Add proper typing to API module (PR #274)
 - [ ] Remove `@ts-ignore` comments in `deno/api/files.ts` (5+ instances)
 - [ ] Standardize Props interface naming
 
@@ -288,7 +293,7 @@ Create standard story template with:
 ## Notes
 
 - Created: 2026-02-06
-- Last updated: 2026-02-08
+- Last updated: 2026-02-09
 - Progress:
   - ✅ **Section 1: Storybook Cleanup - COMPLETE**
     - PR #249: Config fixes
@@ -299,6 +304,7 @@ Create standard story template with:
     - PR #254: Message story image fix
   - 🔄 **Section 2: Code Cleanup - IN PROGRESS**
     - PR #255: Dependency updates (npm packages, @std alignment, ESLint React version)
+    - PRs #272-276: Remove `any` types across codebase (~120 instances)
   - 🔄 **Section 3: Architecture Refactoring - IN PROGRESS**
     - ✅ 3.7 Documentation: ARCHITECTURE.md, CONVENTIONS.md, 14 ADRs, CLAUDE.md
       - PR #256: Architecture docs

--- a/deno/server/inter/http/routes/__tests__/chat.ts
+++ b/deno/server/inter/http/routes/__tests__/chat.ts
@@ -5,9 +5,11 @@ import { Repository } from "../../../../infra/mod.ts";
 import { ensureUser } from "./users.ts";
 import {
   Channel,
+  Emoji,
   EntityId,
   Message,
   ReplaceEntityId,
+  User,
 } from "../../../../types.ts";
 import { AsyncLocalStorage } from "node:async_hooks";
 import API, { LoginError, Result, UserSession } from "@quack/api";
@@ -17,6 +19,19 @@ export type RegistrationRequest = {
   name: string;
   password: string;
   email: string;
+};
+
+type CommandResult = {
+  status: string;
+  json: Record<string, unknown>;
+  channelId: string;
+  events: SSESource | null;
+};
+
+type Attachment = {
+  id: string;
+  fileName: string;
+  contentType: string;
 };
 
 // deno-lint-ignore ban-types
@@ -46,11 +61,12 @@ export class Chat {
 
   currentStep = 0;
 
-  state: any = {};
+  // deno-lint-ignore no-explicit-any
+  state: Record<string, any> = {};
 
-  steps: any[] = [];
+  steps: Array<() => Promise<void>> = [];
 
-  cleanup: any[] = [];
+  cleanup: Array<() => Promise<void>> = [];
 
   appVersion = "client-version";
 
@@ -134,7 +150,7 @@ export class Chat {
     data: Arg<
       { token: string; email: string; password: string; oldPassword: string }
     >,
-    test?: (session: Result) => Promise<any> | any,
+    test?: (session: Result) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const resetData = this.arg(data);
@@ -158,7 +174,9 @@ export class Chat {
     return this;
   }
 
-  nextEvent(fn: (event: any, chat: Chat) => any) {
+  nextEvent(
+    fn: (event: Record<string, unknown>, chat: Chat) => Promise<void> | void,
+  ) {
     this.steps.push(async () => {
       const { event } = await this.eventSource?.next() || {};
       await fn(JSON.parse(event?.data || "{}"), this);
@@ -169,7 +187,7 @@ export class Chat {
   login(
     email = "admin",
     password = "123",
-    test?: (session: Result<UserSession, LoginError>) => Promise<any> | any,
+    test?: (session: Result<UserSession, LoginError>) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       await ensureUser(this.repo, email);
@@ -183,7 +201,10 @@ export class Chat {
     return this;
   }
 
-  checkToken(tokenData: Arg<string>, test?: (body: any) => Promise<any> | any) {
+  checkToken(
+    tokenData: Arg<string>,
+    test?: (body: Record<string, unknown>) => Promise<void> | void,
+  ) {
     this.steps.push(async () => {
       const token = this.arg(tokenData);
       const ret = await this.api.auth.checkRegistrationToken({ token });
@@ -194,7 +215,7 @@ export class Chat {
 
   register(
     data: RegistrationRequest,
-    test?: (body: any) => Promise<any> | any,
+    test?: (body: Record<string, unknown>) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const body = await this.api.auth.register(data);
@@ -212,7 +233,7 @@ export class Chat {
 
   createChannel(
     channelData: Arg<Partial<ReplaceEntityId<Channel>>>,
-    test?: (channel: Channel, chat: Chat) => Promise<any> | any,
+    test?: (channel: Channel, chat: Chat) => Promise<void> | void,
   ) {
     let channelId: string;
     this.steps.push(async () => {
@@ -248,7 +269,7 @@ export class Chat {
     test?: (
       channel: ReplaceEntityId<Channel>,
       chat: Chat,
-    ) => Promise<any> | any,
+    ) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const { userId } = this.arg(data);
@@ -278,7 +299,7 @@ export class Chat {
     test?: (
       channel: ReplaceEntityId<Channel>,
       chat: Chat,
-    ) => Promise<any> | any,
+    ) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const { userId } = this.arg(data);
@@ -326,7 +347,7 @@ export class Chat {
   }
 
   getChannel(
-    fn: (channel: ReplaceEntityId<Channel>, chat: Chat) => Promise<any> | any,
+    fn: (channel: ReplaceEntityId<Channel>, chat: Chat) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const res = await this.agent.request()
@@ -339,7 +360,7 @@ export class Chat {
     return this;
   }
 
-  getEmojis(fn: (emojis: any[]) => Promise<any>) {
+  getEmojis(fn: (emojis: Emoji[]) => Promise<void> | void) {
     this.steps.push(async () => {
       const res = await this.agent.request()
         .get("/api/emojis")
@@ -351,7 +372,7 @@ export class Chat {
     return this;
   }
 
-  getConfig(fn: (config: any) => Promise<any>) {
+  getConfig(fn: (config: Record<string, unknown>) => Promise<void> | void) {
     this.steps.push(async () => {
       const res = await this.agent.request()
         .get("/api/profile/config")
@@ -363,7 +384,7 @@ export class Chat {
     return this;
   }
 
-  getChannels(fn: (channels: Channel[]) => Promise<any> | any) {
+  getChannels(fn: (channels: Channel[]) => Promise<void> | void) {
     this.steps.push(async () => {
       const res = await this.agent.request()
         .get("/api/channels")
@@ -375,7 +396,9 @@ export class Chat {
     return this;
   }
 
-  getUsers(fn: (users: any[], chat: Chat) => Promise<any>) {
+  getUsers(
+    fn: (users: User[], chat: Chat) => Promise<void> | void,
+  ) {
     this.steps.push(async () => {
       const res = await this.agent.request()
         .get("/api/users")
@@ -389,7 +412,7 @@ export class Chat {
 
   getUser(
     userId: string | ((chat: Chat) => string),
-    fn: (user: any) => Promise<any>,
+    fn: (user: User) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const id = typeof userId === "function" ? userId(this) : userId;
@@ -405,7 +428,10 @@ export class Chat {
 
   getMessages(
     queryData: Arg<{ parentId?: string | null }> = {},
-    test?: (messages: any[], chat: Chat) => Promise<any> | any,
+    test?: (
+      messages: Record<string, unknown>[],
+      chat: Chat,
+    ) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const { parentId } = this.arg(queryData);
@@ -429,7 +455,7 @@ export class Chat {
     test?: (
       message: ReplaceEntityId<Message>,
       chat: Chat,
-    ) => Promise<any> | any,
+    ) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const message = this.arg(messageData);
@@ -453,7 +479,7 @@ export class Chat {
       channelId?: string;
       parentId?: string;
       clientId: string;
-      payload?: any;
+      payload?: Record<string, unknown>;
       action: string;
     }>,
   ) {
@@ -487,7 +513,10 @@ export class Chat {
   }
 
   getChannelReadReceipts(
-    fn: (receipts: any[], chat: Chat) => Promise<any> | any,
+    fn: (
+      receipts: Record<string, unknown>[],
+      chat: Chat,
+    ) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const res = await this.agent.request()
@@ -500,7 +529,12 @@ export class Chat {
     return this;
   }
 
-  getReadReceipts(fn: (receipts: any[], chat: Chat) => Promise<any> | any) {
+  getReadReceipts(
+    fn: (
+      receipts: Record<string, unknown>[],
+      chat: Chat,
+    ) => Promise<void> | void,
+  ) {
     this.steps.push(async () => {
       const res = await this.agent.request()
         .get("/api/read-receipts")
@@ -514,7 +548,10 @@ export class Chat {
 
   updateReadReceipts(
     messageId: string | ((chat: Chat) => string),
-    test?: (receipt: any, chat: Chat) => Promise<any> | any,
+    test?: (
+      receipt: Record<string, unknown>,
+      chat: Chat,
+    ) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       const res = await this.agent.request()
@@ -537,8 +574,8 @@ export class Chat {
 
   executeCommand(
     command: string,
-    attachments: any[],
-    test?: (...args: any) => any,
+    attachments: Attachment[],
+    test?: (result: CommandResult) => Promise<void> | void,
   ) {
     this.steps.push(async () => {
       if (!this.channelId) {
@@ -577,7 +614,12 @@ export class Chat {
     return this;
   }
 
-  getPinnedMessages(fn: (messages: any[], chat: Chat) => Promise<any> | any) {
+  getPinnedMessages(
+    fn: (
+      messages: Record<string, unknown>[],
+      chat: Chat,
+    ) => Promise<void> | void,
+  ) {
     this.steps.push(async () => {
       const res = await this.agent.request()
         .get(`/api/channels/${this.channelId}/messages?pinned=true`)
@@ -600,7 +642,7 @@ export class Chat {
     return this;
   }
 
-  step(test: (chat: Chat) => any) {
+  step(test: (chat: Chat) => Promise<void> | void) {
     this.steps.push(async () => {
       await test(this);
     });
@@ -612,7 +654,7 @@ export class Chat {
     return this;
   }
 
-  async then(resolve: (self?: any) => any, reject: (e: unknown) => any) {
+  async then(resolve: (self?: void) => void, reject: (e: unknown) => void) {
     let cleanupStart = false;
     try {
       while (this.steps[this.currentStep]) {

--- a/deno/server/inter/http/routes/__tests__/users.ts
+++ b/deno/server/inter/http/routes/__tests__/users.ts
@@ -5,6 +5,7 @@ import * as enc from "@quack/encryption";
 export const ensureUser = async (
   repo: Repository,
   email: string,
+  // deno-lint-ignore no-explicit-any
   rest: any = {},
 ) => {
   const user = await repo.user.get({ email });

--- a/deno/server/inter/http/routes/auth/__tests__/session.test.ts
+++ b/deno/server/inter/http/routes/auth/__tests__/session.test.ts
@@ -24,15 +24,17 @@ Deno.test("POST /auth/session - wrong params", async () => {
 
   const body = await res.json();
   assertEquals(
-    body.errors?.map((e: any) => e?.params?.missingProperty).sort(),
+    body.errors?.map((e: Record<string, unknown>) =>
+      (e?.params as Record<string, unknown>)?.missingProperty
+    ).sort(),
     ["email", "password"],
   );
 });
 
 Deno.test("Login/logout", async (t) => {
-  let token: any = null;
-  let userId: any = null;
-  let key: any = null;
+  let token: string | null = null;
+  let userId: string | null = null;
+  let key: string | null = null;
   await ensureUser(repo, "admin");
 
   await t.step("POST /auth/session - Create session", async () => {
@@ -92,8 +94,8 @@ Deno.test("Login/logout", async (t) => {
 });
 
 Deno.test("Login/logout - cookies", async (t) => {
-  let token: any = null;
-  let userId: any = null;
+  let token: string | null = null;
+  let userId: string | null = null;
 
   await t.step("POST /auth/session - Create session", async () => {
     const credentials = await enc.prepareCredentials("admin", "123");

--- a/deno/server/inter/http/routes/channel/__tests__/channels.test.ts
+++ b/deno/server/inter/http/routes/channel/__tests__/channels.test.ts
@@ -27,7 +27,7 @@ Deno.test("/api/channels", async () => {
       .login("admin")
       .connectSSE()
       .createChannel({ name: "test-channel-creation" })
-      .nextEvent((event: any) => {
+      .nextEvent((event) => {
         assertEquals(event.type, "channel");
         assertEquals(event.name, "test-channel-creation");
       })
@@ -59,7 +59,7 @@ Deno.test("/api/channels - channel with description", async () => {
         name: "test-channel-with-description",
         description: "This is a test channel description",
       })
-      .nextEvent((event: any) => {
+      .nextEvent((event) => {
         assertEquals(event.type, "channel");
         assertEquals(event.name, "test-channel-with-description");
         assertEquals(event.description, "This is a test channel description");
@@ -84,7 +84,7 @@ Deno.test("/api/channels - other user receives notification about channel", asyn
         users: [member.userIdR],
       });
       await member
-        .nextEvent((event: any) => {
+        .nextEvent((event) => {
           assertEquals(event.type, "channel");
           assertEquals(event.name, "test-channel-creation-2");
         })

--- a/deno/server/inter/http/routes/channel/__tests__/direct.test.ts
+++ b/deno/server/inter/http/routes/channel/__tests__/direct.test.ts
@@ -25,7 +25,7 @@ Deno.test("/api/channels/direct/:userId", async () => {
         .nextEvent((event, chat) => {
           assertEquals(event.type, "message");
           assertEquals(event.flat, "hello");
-          chat.channelId = event.channelId;
+          chat.channelId = event.channelId as string;
           chat.state.directChannelId = event.channelId;
         })
         .getMessages({}, (messages) => {

--- a/deno/server/inter/http/routes/commands/__tests__/commands.test.ts
+++ b/deno/server/inter/http/routes/commands/__tests__/commands.test.ts
@@ -29,7 +29,10 @@ Deno.test("command /echo <text>", async () =>
           assertEquals(event.type, "message");
           assert(event.clientId, "Event should have clientId");
           assertEquals(event.flat, "Hello World!!");
-          assertEquals(event.message.text, "Hello World!!");
+          assertEquals(
+            (event.message as Record<string, unknown>).text,
+            "Hello World!!",
+          );
           assertEquals(event.channelId, chat.channelId);
         })
         .end(),
@@ -37,7 +40,7 @@ Deno.test("command /echo <text>", async () =>
 
 Deno.test("command /emoji <name>", async () =>
   await Chat.test(app, { type: "handler" }, async (agent) => {
-    const state: any = {};
+    const state: Record<string, unknown> = {};
     try {
       await Chat.init(repo, agent)
         .login("admin")
@@ -52,11 +55,11 @@ Deno.test("command /emoji <name>", async () =>
         ], async ({ channelId }) => {
           state.channelId = channelId;
         })
-        .nextEvent((event: any) => {
+        .nextEvent((event) => {
           assertEquals(event.type, "emoji");
           assertEquals(event.shortname, ":party-parrot:");
         })
-        .nextEvent((event: any) => {
+        .nextEvent((event) => {
           assertEquals(event.type, "message");
           assert(event.clientId, "Event should have clientId");
           assertEquals(event.flat, "Emoji :party-parrot: created");
@@ -82,12 +85,14 @@ Deno.test("command /invite", async () => {
       .createChannel({ name: "test-commands-invite" })
       .connectSSE()
       .executeCommand("/invite", [], ({ json }) => {
-        url = json.data;
+        url = json.data as string;
       })
-      .nextEvent((event: any) => {
+      .nextEvent((event) => {
         assertEquals(event.type, "message");
         assert(event.clientId, "Event should have clientId");
-        const m = event.flat.match("(https?://.*/invite/[0-9a-f]{32})");
+        const m = (event.flat as string).match(
+          "(https?://.*/invite/[0-9a-f]{32})",
+        );
         assert(m, "Result should contain invitation link");
         assertEquals(m[1], url);
       })
@@ -108,7 +113,7 @@ Deno.test("command /avatar", async () => {
           contentType: "image/gif",
         },
       ])
-      .nextEvent((event: any) => {
+      .nextEvent((event) => {
         assertEquals(event.type, "user");
         assertEquals(event.avatarFileId, "party-parrot");
       })
@@ -129,8 +134,8 @@ Deno.test("command /version", async () => {
       .nextEvent((event) => {
         assertEquals(event.type, "message");
         assert(event.clientId, "Event should have clientId");
-        assertEquals(event.flat.includes("server-version"), true);
-        assertEquals(event.flat.includes("client-version"), true);
+        assertEquals((event.flat as string).includes("server-version"), true);
+        assertEquals((event.flat as string).includes("client-version"), true);
       })
       .end();
   });
@@ -146,10 +151,10 @@ Deno.test("command /help", async () => {
       .nextEvent((event) => {
         assertEquals(event.type, "message");
         assert(event.clientId, "Event should have clientId");
-        assertEquals(event.flat.includes("/avatar"), true);
-        assertEquals(event.flat.includes("/emoji"), true);
-        assertEquals(event.flat.includes("/invite"), true);
-        assertEquals(event.flat.includes("/version"), true);
+        assertEquals((event.flat as string).includes("/avatar"), true);
+        assertEquals((event.flat as string).includes("/emoji"), true);
+        assertEquals((event.flat as string).includes("/invite"), true);
+        assertEquals((event.flat as string).includes("/version"), true);
       })
       .end();
   });
@@ -169,7 +174,7 @@ Deno.test("command /leave", async () => {
       .nextEvent((event, chat) => {
         assertEquals(event.type, "channel");
         assert(
-          !event.users.find((u: any) => u === chat.userId),
+          !(event.users as string[]).find((u) => u === chat.userId),
           "Updated channel should not contain user",
         );
       })

--- a/deno/server/inter/http/routes/emojis/__tests__/emojis.test.ts
+++ b/deno/server/inter/http/routes/emojis/__tests__/emojis.test.ts
@@ -43,7 +43,7 @@ Deno.test("Adding emojis and listing them", async () => {
           fileName: "smile.png",
           contentType: "image/png",
         }])
-        .nextEvent((event: any) => {
+        .nextEvent((event) => {
           assertEquals(event.type, "emoji");
           assertEquals(event.shortname, ":smile:");
         })

--- a/deno/server/inter/http/routes/interactions/__tests__/interaction.test.ts
+++ b/deno/server/inter/http/routes/interactions/__tests__/interaction.test.ts
@@ -2,7 +2,7 @@ import { Agent } from "@planigale/testing";
 import { assertEquals } from "@std/assert";
 import { createApp } from "../../__tests__/app.ts";
 import { Chat } from "../../__tests__/chat.ts";
-import { MessageInteractionEvent } from "../../../../../events.ts";
+import type { Event, MessageInteractionEvent } from "../../../../../events.ts";
 import { EntityId } from "../../../../../types.ts";
 
 const { app, repo, core } = createApp();
@@ -16,7 +16,7 @@ Deno.test("POST /api/interactions - dispatching interactions", async (t) => {
         .createChannel({ name: "test-messages-interactions" });
       const { promise, resolve, reject } = Promise.withResolvers<void>();
       (async () => {
-        const event: any = await new Promise((resolve) =>
+        const event: Event = await new Promise((resolve) =>
           core.events.once(resolve)
         );
         if (event.type !== "message:interaction") {
@@ -50,7 +50,7 @@ Deno.test("POST /api/interactions - graceful shutdown", async (t) => {
         .login("admin")
         .createChannel({ name: "test-messages-interactions" });
       for (let i = 0; i < 5; i++) {
-        const { promise, resolve } = Promise.withResolvers<any>();
+        const { promise, resolve } = Promise.withResolvers<Event>();
         core.events.once(resolve);
         await admin.interaction({ action: "test", clientId: "clientId" });
         await promise;

--- a/deno/server/inter/http/routes/messages/__tests__/format.test.ts
+++ b/deno/server/inter/http/routes/messages/__tests__/format.test.ts
@@ -18,7 +18,11 @@ Deno.test("Check all validations for message field", async (t) => {
     name: "messages-formating-check",
     users: [EntityId.from(userId)],
   }, async (channelId) => {
-    const testPart = async (status: number, name: string, message: any) =>
+    const testPart = async (
+      status: number,
+      name: string,
+      message: Record<string, unknown> | Record<string, unknown>[],
+    ) =>
       await t.step(name, async () =>
         await agent.request()
           .post(`/api/channels/${channelId}/messages/`)

--- a/deno/server/inter/http/routes/messages/__tests__/messages.test.ts
+++ b/deno/server/inter/http/routes/messages/__tests__/messages.test.ts
@@ -427,7 +427,11 @@ Deno.test("Messages history", async (t) => {
 
       const body = await res.json();
       assertEquals(body.length, 3);
-      assertEquals(body.map((m: any) => m.flat), ["t2", "t1", "t0"]);
+      assertEquals(body.map((m: Record<string, unknown>) => m.flat), [
+        "t2",
+        "t1",
+        "t0",
+      ]);
     });
 
     await t.step("GET /api/channels/:channelId/messages - limit", async () => {
@@ -438,7 +442,10 @@ Deno.test("Messages history", async (t) => {
 
       const body = await res.json();
       assertEquals(body.length, 2);
-      assertEquals(body.map((m: any) => m.flat), ["t2", "t1"]);
+      assertEquals(body.map((m: Record<string, unknown>) => m.flat), [
+        "t2",
+        "t1",
+      ]);
     });
 
     await t.step(
@@ -455,7 +462,10 @@ Deno.test("Messages history", async (t) => {
 
         const body = await res.json();
         assertEquals(body.length, 2);
-        assertEquals(body.map((m: any) => m.flat), ["t1", "t0"]);
+        assertEquals(body.map((m: Record<string, unknown>) => m.flat), [
+          "t1",
+          "t0",
+        ]);
       },
     );
     await t.step("GET /api/channels/:channelId/messages - before", async () => {
@@ -470,7 +480,7 @@ Deno.test("Messages history", async (t) => {
 
       const body = await res.json();
       assertEquals(body.length, 1);
-      assertEquals(body.map((m: any) => m.flat), ["t0"]);
+      assertEquals(body.map((m: Record<string, unknown>) => m.flat), ["t0"]);
     });
     await t.step("GET /api/channels/:channelId/messages - after", async () => {
       const res = await agent.request()
@@ -484,7 +494,10 @@ Deno.test("Messages history", async (t) => {
 
       const body = await res.json();
       assertEquals(body.length, 2);
-      assertEquals(body.map((m: any) => m.flat), ["t2", "t1"]);
+      assertEquals(body.map((m: Record<string, unknown>) => m.flat), [
+        "t2",
+        "t1",
+      ]);
     });
     await t.step("GET /api/channels/:channelId/messages - pinend", async () => {
       const res = await agent.request()
@@ -494,7 +507,7 @@ Deno.test("Messages history", async (t) => {
 
       const body = await res.json();
       assertEquals(body.length, 1);
-      assertEquals(body.map((m: any) => m.flat), ["t1"]);
+      assertEquals(body.map((m: Record<string, unknown>) => m.flat), ["t1"]);
     });
     await t.step("GET /api/channels/:channelId/messages - offset", async () => {
       const res = await agent.request()
@@ -504,7 +517,7 @@ Deno.test("Messages history", async (t) => {
 
       const body = await res.json();
       assertEquals(body.length, 1);
-      assertEquals(body.map((m: any) => m.flat), ["t2"]);
+      assertEquals(body.map((m: Record<string, unknown>) => m.flat), ["t2"]);
     });
     await t.step("GET /api/channels/:channelId/messages - search", async () => {
       const res = await agent.request()
@@ -514,7 +527,7 @@ Deno.test("Messages history", async (t) => {
 
       const body = await res.json();
       assertEquals(body.length, 1);
-      assertEquals(body.map((m: any) => m.flat), ["t1"]);
+      assertEquals(body.map((m: Record<string, unknown>) => m.flat), ["t1"]);
     });
   });
   await agent.close();

--- a/deno/server/inter/http/routes/messages/__tests__/notifications.test.ts
+++ b/deno/server/inter/http/routes/messages/__tests__/notifications.test.ts
@@ -13,7 +13,7 @@ Deno.test("webhook should be sent", async (t) => {
       },
     ],
   });
-  const { promise, resolve } = Promise.withResolvers<any>();
+  const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
   const srv = Deno.serve({
     port: 8123,
     handler: async (req) => {
@@ -34,7 +34,7 @@ Deno.test("webhook should be sent", async (t) => {
   const event = await promise;
 
   assertEquals(event.type, "message");
-  assertEquals(event.event.flat, "test");
+  assertEquals((event.event as Record<string, unknown>).flat, "test");
 
   await srv.shutdown();
   await app.close();
@@ -72,7 +72,7 @@ Deno.test("webhook should be called once", async (t) => {
       },
     ],
   });
-  const { promise, resolve } = Promise.withResolvers<any>();
+  const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
   const srv = Deno.serve({
     port: 8123,
     handler: async (req) => {
@@ -96,7 +96,7 @@ Deno.test("webhook should be called once", async (t) => {
 
   assertEquals(calls, 1);
   assertEquals(event.type, "message");
-  assertEquals(event.event.flat, "test");
+  assertEquals((event.event as Record<string, unknown>).flat, "test");
 
   await srv.shutdown();
   await app.close();

--- a/deno/server/inter/http/routes/messages/__tests__/pinning.test.ts
+++ b/deno/server/inter/http/routes/messages/__tests__/pinning.test.ts
@@ -23,26 +23,26 @@ Deno.test("Pinning other user messsage", async (t) => {
         flat: "Hello",
         message: { text: "Hello" },
         clientId: "hello",
-      }, (msg: any) => {
-        pinMessageId = msg.id;
+      }, (msg) => {
+        pinMessageId = msg.id as string;
       });
       await t.step("pinning message", async () => {
         await member.pinMessage({ messageId: pinMessageId })
-          .getPinnedMessages((messages: any) => {
+          .getPinnedMessages((messages) => {
             assertEquals(messages.length, 1);
             assertEquals(messages[0].id, pinMessageId);
           });
-        await admin.getPinnedMessages((messages: any) => {
+        await admin.getPinnedMessages((messages) => {
           assertEquals(messages.length, 1);
           assertEquals(messages[0].id, pinMessageId);
         });
       });
       await t.step("unpinning message by other user", async () => {
         await admin.pinMessage({ messageId: pinMessageId, pinned: false })
-          .getPinnedMessages((messages: any) => {
+          .getPinnedMessages((messages) => {
             assertEquals(messages.length, 0);
           });
-        await member.getPinnedMessages((messages: any) => {
+        await member.getPinnedMessages((messages) => {
           assertEquals(messages.length, 0);
         });
       });

--- a/deno/server/inter/http/routes/messages/__tests__/react.test.ts
+++ b/deno/server/inter/http/routes/messages/__tests__/react.test.ts
@@ -28,9 +28,13 @@ Deno.test("PUT /api/messages/:messageId/react - sending reacts to messages", asy
           messageId: state.messageId,
           reaction: ":thumbsup:",
         }))
-          .getMessages({}, (messages: any) => {
-            assertEquals(messages[0].reactions.length, 1);
-            assertEquals(messages[0].reactions[0], {
+          .getMessages({}, (messages) => {
+            const reactions = messages[0].reactions as Record<
+              string,
+              unknown
+            >[];
+            assertEquals(reactions.length, 1);
+            assertEquals(reactions[0], {
               userId: admin.userId,
               reaction: ":thumbsup:",
             });
@@ -38,7 +42,7 @@ Deno.test("PUT /api/messages/:messageId/react - sending reacts to messages", asy
       });
 
       await t.step("checking reactions by second user", async () => {
-        await member.getMessages({}, (messages: any, { state }) => {
+        await member.getMessages({}, (messages, { state }) => {
           state.messageId = messages[0].id;
         });
       });
@@ -54,17 +58,21 @@ Deno.test("PUT /api/messages/:messageId/react - sending reacts to messages", asy
               messageId: state.messageId,
               reaction: ":thumbsup:",
             }))
-            .getMessages({}, (messages: any) => {
-              assertEquals(messages[0].reactions.length, 3);
-              assertEquals(messages[0].reactions[0], {
+            .getMessages({}, (messages) => {
+              const reactions = messages[0].reactions as Record<
+                string,
+                unknown
+              >[];
+              assertEquals(reactions.length, 3);
+              assertEquals(reactions[0], {
                 userId: admin.userId,
                 reaction: ":thumbsup:",
               });
-              assertEquals(messages[0].reactions[1], {
+              assertEquals(reactions[1], {
                 userId: member.userId,
                 reaction: ":thumbsdown:",
               });
-              assertEquals(messages[0].reactions[2], {
+              assertEquals(reactions[2], {
                 userId: member.userId,
                 reaction: ":thumbsup:",
               });
@@ -77,13 +85,17 @@ Deno.test("PUT /api/messages/:messageId/react - sending reacts to messages", asy
           messageId: state.messageId,
           reaction: ":thumbsup:",
         }))
-          .getMessages({}, (messages: any) => {
-            assertEquals(messages[0].reactions.length, 2);
-            assertEquals(messages[0].reactions[0], {
+          .getMessages({}, (messages) => {
+            const reactions = messages[0].reactions as Record<
+              string,
+              unknown
+            >[];
+            assertEquals(reactions.length, 2);
+            assertEquals(reactions[0], {
               userId: admin.userId,
               reaction: ":thumbsup:",
             });
-            assertEquals(messages[0].reactions[1], {
+            assertEquals(reactions[1], {
               userId: member.userId,
               reaction: ":thumbsdown:",
             });
@@ -120,10 +132,11 @@ Deno.test("PUT /api/messages/:messageId/react - SSR about reactions", async (t) 
             messageId: state.messageId,
             reaction: ":thumbsup:",
           }));
-        await member.nextEvent((event: any) => {
+        await member.nextEvent((event) => {
+          const reactions = event.reactions as Record<string, unknown>[];
           assertEquals(event.type, "message");
-          assertEquals(event.reactions.length, 1);
-          assertEquals(event.reactions[0], {
+          assertEquals(reactions.length, 1);
+          assertEquals(reactions[0], {
             userId: admin.userId,
             reaction: ":thumbsup:",
           });
@@ -135,9 +148,10 @@ Deno.test("PUT /api/messages/:messageId/react - SSR about reactions", async (t) 
             messageId: state.messageId,
             reaction: ":thumbsup:",
           }));
-        await member.nextEvent((event: any) => {
+        await member.nextEvent((event) => {
+          const reactions = event.reactions as Record<string, unknown>[];
           assertEquals(event.type, "message");
-          assertEquals(event.reactions.length, 0);
+          assertEquals(reactions.length, 0);
         });
       });
     } finally {

--- a/deno/server/inter/http/routes/messages/__tests__/threads.test.ts
+++ b/deno/server/inter/http/routes/messages/__tests__/threads.test.ts
@@ -15,7 +15,7 @@ Deno.test("sending messages to threads", async (t) => {
       })
       .sendMessage({
         flat: "Hello",
-      }, (msg: any, { state }) => {
+      }, (msg, { state }) => {
         state.parentId = msg.id;
       })
       .sendMessage({
@@ -23,15 +23,15 @@ Deno.test("sending messages to threads", async (t) => {
       })
       .sendMessage(({ state }) => ({ flat: "msg1", parentId: state.parentId }))
       .sendMessage(({ state }) => ({ flat: "msg2", parentId: state.parentId }))
-      .getMessages({ parentId: null }, (messages: any) => {
+      .getMessages({ parentId: null }, (messages) => {
         assertEquals(messages.length, 3);
-        assertEquals(messages[1].thread.length, 2);
+        assertEquals((messages[1].thread as unknown[]).length, 2);
       })
       .getMessages(
         ({ state }) => ({ parentId: state.parentId }),
-        (messages: any, { state }) => {
+        (messages, { state }) => {
           assertEquals(messages.length, 3);
-          assertEquals(messages[0].thread.length, 2);
+          assertEquals((messages[0].thread as unknown[]).length, 2);
           assertEquals(messages[0].id, state.parentId);
         },
       )

--- a/deno/server/inter/http/routes/profile/__tests__/profile.test.ts
+++ b/deno/server/inter/http/routes/profile/__tests__/profile.test.ts
@@ -23,7 +23,7 @@ Deno.test("GET /api/profile/config - getConfig", async () => {
     await admin.login("admin")
       .createChannel({ name: "Test" });
     await admin.executeCommand("/main", [])
-      .getConfig(async (body: any) => {
+      .getConfig(async (body) => {
         assertEquals(body.appVersion, "1.2.3");
         assertEquals(body.mainChannelId, admin.channelId);
       })

--- a/deno/server/inter/http/routes/readReceipt/__tests__/readReceipt.test.ts
+++ b/deno/server/inter/http/routes/readReceipt/__tests__/readReceipt.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Chat } from "../../__tests__/chat.ts";
 import { createApp } from "../../__tests__/app.ts";
 
@@ -19,10 +19,9 @@ Deno.test("/api/channels/:channelId/read-receipts", async () =>
         }, (msg, { state }) => {
           state.messageId = msg.id;
         })
-        .getChannelReadReceipts((receipts: any, self) => {
-          const receipt = receipts.find((r: any) =>
-            r.channelId === self.channelId
-          );
+        .getChannelReadReceipts((receipts, self) => {
+          const receipt = receipts.find((r) => r.channelId === self.channelId);
+          assert(receipt, "Receipt should exist");
           assertEquals(receipt.count, 0);
           assertEquals(receipt.lastMessageId, self.state.messageId);
         })
@@ -51,12 +50,12 @@ Deno.test("/api/channels/:channelId/read-receipts - SSE", async () =>
 
       await admin.connectSSE();
       await member
-        .getMessages({}, async (messages: any, { state, channelId }) => {
+        .getMessages({}, async (messages, { state, channelId }) => {
           state.messageId = messages[0].id;
         })
         .updateReadReceipts(({ state }) => state.messageId);
 
-      await admin.nextEvent((event: any) => {
+      await admin.nextEvent((event) => {
         assertEquals(event.type, "readReceipt");
         assertEquals(event.lastMessageId, member.state.messageId);
         assertEquals(event.userId, member.userId);
@@ -88,7 +87,7 @@ Deno.test("/api/read-receipts", async () => {
         clientId: "test2",
       });
       await member
-        .getMessages({}, async (messages: any, { state }) => {
+        .getMessages({}, async (messages, { state }) => {
           state.messageId = messages[0].id;
         })
         .updateReadReceipts(({ state }) => state.messageId);
@@ -102,11 +101,10 @@ Deno.test("/api/read-receipts", async () => {
         message: { text: "Hello" },
         clientId: "test4",
       });
-      await member.getReadReceipts((receipts: any) => {
+      await member.getReadReceipts((receipts) => {
         assertEquals(receipts.length, 1);
-        const receipt = receipts.find((r: any) =>
-          r.channelId === member.channelId
-        );
+        const receipt = receipts.find((r) => r.channelId === member.channelId);
+        assert(receipt, "Receipt should exist");
         assertEquals(receipt.count, 2);
       });
     } finally {

--- a/deno/server/inter/http/routes/users/__tests__/registration.test.ts
+++ b/deno/server/inter/http/routes/users/__tests__/registration.test.ts
@@ -21,8 +21,8 @@ Deno.test("POST /api/users - user creation flow", async (t) => {
         .sendMessage({ flat: "secret" });
 
       await t.step("creating invite", async () => {
-        await admin.executeCommand("/invite", [], ({ json }: any) => {
-          url = json.data;
+        await admin.executeCommand("/invite", [], ({ json }) => {
+          url = json.data as string;
         });
         const m = url.match(/https?:\/\/.*\/invite\/(.*)$/);
         assert(m);
@@ -31,8 +31,8 @@ Deno.test("POST /api/users - user creation flow", async (t) => {
 
       await t.step("creating second invite", async () => {
         let url2: string = "";
-        await admin.executeCommand("/invite", [], ({ json }: any) => {
-          url2 = json.data;
+        await admin.executeCommand("/invite", [], ({ json }) => {
+          url2 = json.data as string;
         });
         const m = url2.match(/https?:\/\/.*\/invite\/(.*)$/);
         assert(m);
@@ -66,7 +66,7 @@ Deno.test("POST /api/users - user creation flow", async (t) => {
             assert(session.secrets._iv);
           })
           .openChannel("user-invite-test")
-          .getMessages({}, (msgs: any[]) => {
+          .getMessages({}, (msgs) => {
             assertEquals(msgs[0].flat, "secret");
           });
       });

--- a/deno/server/inter/http/routes/users/__tests__/users.test.ts
+++ b/deno/server/inter/http/routes/users/__tests__/users.test.ts
@@ -29,7 +29,7 @@ Deno.test("GET /api/users/:userId - getUser with an id and alias", async () => {
       })
       .getUser(({ state }) => state.member.id, async (user: User) => {
         assert(user.name === "Member");
-        assert((user as any).secrets === undefined);
+        assert((user as Record<string, unknown>).secrets === undefined);
         assert(user.publicKey);
       })
       .end();
@@ -46,8 +46,8 @@ Deno.test("GET /api/users - getAllUsers", async () => {
         const userNames = users.map((u: User) => u.name);
         assert(userNames.includes("Admin"));
         assert(userNames.includes("Member"));
-        assert((users[0] as any).password === undefined);
-        assert((users[1] as any).password === undefined);
+        assert((users[0] as Record<string, unknown>).password === undefined);
+        assert((users[1] as Record<string, unknown>).password === undefined);
       })
       .end();
   });
@@ -63,8 +63,8 @@ Deno.test("POST /api/users - user creation flow", async () => {
       await admin.login("admin")
         .createChannel({ name: "user-invite-test" })
         .sendMessage({ flat: "secret" })
-        .executeCommand("/invite", [], ({ json }: any) => {
-          url = json.data;
+        .executeCommand("/invite", [], ({ json }) => {
+          url = json.data as string;
         });
       const m = url.match(/https?:\/\/.*\/invite\/(.*)$/);
       assert(m);
@@ -78,7 +78,7 @@ Deno.test("POST /api/users - user creation flow", async () => {
         })
         .login("jack", "test123")
         .openChannel("user-invite-test")
-        .getMessages({}, (msgs: any[]) => {
+        .getMessages({}, (msgs) => {
           assertEquals(msgs[0].flat, "secret");
         })
         .end();


### PR DESCRIPTION
## Summary

- Replace ~98 `any` instances across 19 test files with proper types
- Add `CommandResult` and `Attachment` types to the `Chat` test helper
- Use domain types (`User[]`, `Emoji[]`, `Channel[]`, `Event`) where callers expect them
- Use `Record<string, unknown>` for untyped JSON boundaries (messages, events, receipts)
- Add `as` casts and `assert()` narrowing where property access requires it
- Keep `Record<string, any>` with `deno-lint-ignore` for dynamic test state scratchpad
- Keep `rest: any` with `deno-lint-ignore` in `users.ts` (excess property check issue)

PR 5 of 5 in the remove-any-types plan (PRs #272-275 covered backend core, storage, API, frontend).

## Test plan

- [x] `deno task check` — 115 tests pass, 0 type errors
- [x] `grep -r 'any' --include='*.test.ts'` in routes — 0 matches
- [x] Only 2 justified `any` remain in test helpers (with `deno-lint-ignore`)