### PR TITLE
ci: pin deno to 2.6.8 across remaining workflows

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -18,7 +18,7 @@ jobs:
 
     - uses: denoland/setup-deno@v2
       with:
-        deno-version: '2.x'
+        deno-version: '2.6.8'
 
     - run: deno install --allow-scripts
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: denoland/setup-deno@v2
       with:
-        deno-version: '2.x'
+        deno-version: '2.6.8'
     - run: deno install --allow-scripts
     - name: Install frontend dependencies
       working-directory: app

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: denoland/setup-deno@v2
       with:
-        deno-version: '2.x'
+        deno-version: '2.6.8'
     - run: deno install --allow-scripts
     - run: deno task migrate:tests
     - run: deno task check


### PR DESCRIPTION
## Summary

Pins `denoland/setup-deno` to `2.6.8` in `dev.yml`, `docker.yml`, and `apps.yml`, matching `tests.yml` and the production runtime (`Dockerfile`: `denoland/deno:alpine-2.6.8`).

## Why

The floating `deno-version: '2.x'` pulls deno 2.8.x, where a V8 tightening makes the core serializer throw at runtime (`Cannot set property parent of [object Object] which has only a getter`), failing `deno task check`. This blocked the `dev -> main` release PR (#295) via `dev.yml`, and would block the release Docker build via `docker.yml`. Locally and on 2.6.8 the full suite passes.

## Changes

- `.github/workflows/dev.yml`: `2.x` -> `2.6.8`
- `.github/workflows/docker.yml`: `2.x` -> `2.6.8`
- `.github/workflows/apps.yml`: `2.x` -> `2.6.8`

## Follow-up

Migrating the codebase to deno 2.8 (serializer getter writes, etc.) remains a separate effort; this pin aligns CI with the deployed runtime in the meantime.