### PR TITLE
ci(release): trigger docker build via workflow_dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
   workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      version: ${{ steps.version.outputs.result }}
+      actions: write
 
     steps:
       - name: Extract version from labels
@@ -50,9 +49,16 @@ jobs:
 
             core.info(`Created release ${version}`);
 
-  docker:
-    needs: release
-    uses: ./.github/workflows/docker.yml
-    with:
-      version: ${{ needs.release.outputs.version }}
-    secrets: inherit
+      - name: Trigger Docker image build
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ steps.version.outputs.result }}';
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docker.yml',
+              ref: 'main',
+              inputs: { version },
+            });
+            core.info(`Dispatched docker.yml build for ${version}`);


### PR DESCRIPTION
## Summary

Fixes the release workflow, which `startup_failure`d on the v3.5.1 release (PR #295) — the GitHub Release and image build never ran.

## Root cause

The `docker:` job added to `release.yml` called `docker.yml` as a **reusable workflow** (`uses: ./.github/workflows/docker.yml`) from a `pull_request`-triggered workflow. v3.5.1 was the first release to exercise it, and that call fails workflow validation at startup (the whole run dies in ~1s with zero jobs and no usable error — GitHub only reports "workflow file issue"). The previous v3.5.0 release predated this job and ran fine.

## Fix

Replace the reusable-workflow call with an explicit `workflow_dispatch` of `docker.yml`:

- `release.yml`: after creating the Release, dispatch `docker.yml` on `main` with the version via `actions/github-script` (`createWorkflowDispatch`). Adds `actions: write` permission (required to dispatch) and drops the now-unused `outputs`/`docker` reusable job.
- `docker.yml`: add an optional `version` input to `workflow_dispatch` so the dispatched build tags the image correctly (`APP_VERSION` / image tag already fall back to `github.ref_name`).

This avoids the fragile reusable-call-from-`pull_request` pattern. A token-created release/tag does not trigger `on: push: tags`, so the explicit dispatch is the reliable chain.

## Note

v3.5.1 was recovered manually (tag pushed → image built & published, Release created). This fix takes effect from the next release.