### PR TITLE
fix(session): make auth sessions persistent across restarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ PBKDF2 key derivation → ECDH key exchange (P-256) → AES-GCM message encrypti
 - **File naming**: Backend `camelCase.ts`, components `PascalCase.tsx`, hooks `useXxx.ts`, models `camelCase.ts`, tests `__tests__/name.test.ts`
 - **Backend barrels**: `mod.ts`; **Frontend**: no barrels (direct imports)
 - **Import order**: external libs → types → core/models → components (atoms→molecules→organisms) → utils
+- **No code comments**: do not add explanatory comments; code should be self-documenting through clear naming
 - Never mention AI usage in code or documentation
 - Do not add AI co-author lines to commits
 

--- a/deno/server/core/session/constants.ts
+++ b/deno/server/core/session/constants.ts
@@ -1,4 +1,1 @@
-// Session lifetime, shared by the server-side expiry (MongoDB TTL index on
-// `expires`) and the auth cookies' `Max-Age`. Single source of truth so the
-// cookie and the persisted session always agree on how long a login lasts.
-export const SESSION_TTL_SECONDS = 60 * 60 * 24 * 60; // 60 days
+export const SESSION_TTL_SECONDS = 60 * 60 * 24 * 60;

--- a/deno/server/core/session/constants.ts
+++ b/deno/server/core/session/constants.ts
@@ -1,0 +1,4 @@
+// Session lifetime, shared by the server-side expiry (MongoDB TTL index on
+// `expires`) and the auth cookies' `Max-Age`. Single source of truth so the
+// cookie and the persisted session always agree on how long a login lasts.
+export const SESSION_TTL_SECONDS = 60 * 60 * 24 * 60; // 60 days

--- a/deno/server/core/session/create.ts
+++ b/deno/server/core/session/create.ts
@@ -3,6 +3,7 @@ import * as argon2 from "argon2";
 import { createCommand } from "../command.ts";
 import * as enc from "@quack/encryption";
 import { PasswordResetRequired } from "../errors.ts";
+import { SESSION_TTL_SECONDS } from "./constants.ts";
 
 export default createCommand({
   type: "session:create",
@@ -23,6 +24,7 @@ export default createCommand({
   }
 
   if (!await argon2.verify(user.secrets.password.hash, password)) return null;
-  const sessionId = await repo.session.create({ userId: user.id });
+  const expires = new Date(Date.now() + SESSION_TTL_SECONDS * 1000);
+  const sessionId = await repo.session.create({ userId: user.id, expires });
   return sessionId;
 });

--- a/deno/server/infra/repo/sessionRepo.ts
+++ b/deno/server/infra/repo/sessionRepo.ts
@@ -27,8 +27,6 @@ export class SessionRepo {
     return deserialize(ret.insertedId);
   }
 
-  // Sliding expiration: push the session's expiry forward so active users are
-  // not logged out. The TTL index on `expires` removes it once it lapses.
   async refresh(id: EntityId, expires: Date): Promise<void> {
     const { db } = await this.connect();
     await db.collection("sessions").updateOne(

--- a/deno/server/infra/repo/sessionRepo.ts
+++ b/deno/server/infra/repo/sessionRepo.ts
@@ -10,18 +10,31 @@ export class SessionRepo {
   }
 
   #generateToken() {
-    return Math.random().toString(36).substring(2, 15) +
-      Math.random().toString(36).substring(2, 15);
+    return Array.from(
+      crypto.getRandomValues(new Uint8Array(32)),
+      (b) => b.toString(16).padStart(2, "0"),
+    ).join("");
   }
 
-  async create(data: { userId: EntityId }): Promise<EntityId> {
+  async create(data: { userId: EntityId; expires: Date }): Promise<EntityId> {
     const { db } = await this.connect();
     const newSession = serialize({
       userId: data.userId,
       token: this.#generateToken(),
+      expires: data.expires,
     });
     const ret = await db.collection("sessions").insertOne(newSession);
     return deserialize(ret.insertedId);
+  }
+
+  // Sliding expiration: push the session's expiry forward so active users are
+  // not logged out. The TTL index on `expires` removes it once it lapses.
+  async refresh(id: EntityId, expires: Date): Promise<void> {
+    const { db } = await this.connect();
+    await db.collection("sessions").updateOne(
+      serialize({ id }),
+      { $set: { expires } },
+    );
   }
 
   async remove(data: { id?: EntityId }): Promise<void> {

--- a/deno/server/inter/http/cookies.ts
+++ b/deno/server/inter/http/cookies.ts
@@ -1,11 +1,6 @@
 import type { Core } from "../../core/mod.ts";
 import { SESSION_TTL_SECONDS } from "../../core/session/constants.ts";
 
-// Options for the auth cookies (`token`, `key`). Persistent (`maxAge`) so the
-// login survives a browser/app restart instead of dying with the browser
-// session — the previous behaviour, which logged users off constantly.
-// `secure` is enabled only when the app is served over HTTPS so local HTTP
-// development and tests still receive the cookies.
 export function authCookieOptions(core: Core) {
   return {
     httpOnly: true,

--- a/deno/server/inter/http/cookies.ts
+++ b/deno/server/inter/http/cookies.ts
@@ -1,0 +1,17 @@
+import type { Core } from "../../core/mod.ts";
+import { SESSION_TTL_SECONDS } from "../../core/session/constants.ts";
+
+// Options for the auth cookies (`token`, `key`). Persistent (`maxAge`) so the
+// login survives a browser/app restart instead of dying with the browser
+// session — the previous behaviour, which logged users off constantly.
+// `secure` is enabled only when the app is served over HTTPS so local HTTP
+// development and tests still receive the cookies.
+export function authCookieOptions(core: Core) {
+  return {
+    httpOnly: true,
+    path: "/",
+    maxAge: SESSION_TTL_SECONDS,
+    sameSite: "Lax" as const,
+    secure: core.config.baseUrl?.startsWith("https") ?? false,
+  };
+}

--- a/deno/server/inter/http/routes/auth/__tests__/session.test.ts
+++ b/deno/server/inter/http/routes/auth/__tests__/session.test.ts
@@ -50,15 +50,13 @@ Deno.test("Login/logout", async (t) => {
     token = body.token;
     userId = body.userId;
     key = credentials.login.key;
-    assert(
-      res.headers.get("Set-Cookie")?.includes(`key=${credentials.login.key}`),
-    );
-    assert(
-      /^token=.+; HttpOnly; Path=\/$/.test(
-        res.headers.get("Set-Cookie")?.toString() ?? "",
-      ),
-      "Set-Cookie header is not correct",
-    );
+    const setCookie = res.headers.get("Set-Cookie")?.toString() ?? "";
+    assert(setCookie.includes(`key=${credentials.login.key}`));
+    assert(/token=[^;]+/.test(setCookie), "token cookie is set");
+    assert(setCookie.includes("HttpOnly"), "token cookie is HttpOnly");
+    assert(setCookie.includes("Path=/"), "token cookie has Path=/");
+    assert(setCookie.includes("Max-Age="), "token cookie is persistent");
+    assert(setCookie.includes("SameSite=Lax"), "token cookie is SameSite=Lax");
   });
 
   await t.step("GET /auth/session - Get session with bearer", async () => {
@@ -109,12 +107,12 @@ Deno.test("Login/logout - cookies", async (t) => {
     assert(body.id);
     token = body.token;
     userId = body.userId;
-    assert(
-      /^token=.+; HttpOnly; Path=\/$/.test(
-        res.headers.get("Set-Cookie")?.toString() ?? "",
-      ),
-      "Set-Cookie header is not correct",
-    );
+    const setCookie = res.headers.get("Set-Cookie")?.toString() ?? "";
+    assert(/token=[^;]+/.test(setCookie), "token cookie is set");
+    assert(setCookie.includes("HttpOnly"), "token cookie is HttpOnly");
+    assert(setCookie.includes("Path=/"), "token cookie has Path=/");
+    assert(setCookie.includes("Max-Age="), "token cookie is persistent");
+    assert(setCookie.includes("SameSite=Lax"), "token cookie is SameSite=Lax");
   });
 
   await t.step("GET /auth/session - Get session with cookie", async () => {

--- a/deno/server/inter/http/routes/auth/getSession.ts
+++ b/deno/server/inter/http/routes/auth/getSession.ts
@@ -1,23 +1,32 @@
 import { Res, Route } from "@planigale/planigale";
 import { Core } from "../../../../core/mod.ts";
+import { authCookieOptions } from "../../cookies.ts";
+import { SESSION_TTL_SECONDS } from "../../../../core/session/constants.ts";
 
-export default (_core: Core) =>
+export default (core: Core) =>
   new Route({
     public: true,
     method: "GET",
     url: "/session",
-    handler: (req) => {
+    handler: async (req) => {
       if (req.state.session) {
+        // Sliding expiration: extend the persisted session and re-issue the
+        // cookies with a fresh Max-Age so active users stay logged in.
+        const expires = new Date(Date.now() + SESSION_TTL_SECONDS * 1000);
+        await core.repo.session.refresh(req.state.session.id, expires);
+
+        const cookieOpts = authCookieOptions(core);
         const res = Res.json({
           ...req.state.session,
           user: req.state.user.id, // FIXME: remove
           status: "ok", // FIXME: remove
           key: req.cookies.get("key"),
         });
-        res.cookies.set("token", req.state.session.token, {
-          httpOnly: true,
-          path: "/",
-        });
+        res.cookies.set("token", req.state.session.token, cookieOpts);
+        const key = req.cookies.get("key");
+        if (key) {
+          res.cookies.set("key", key, cookieOpts);
+        }
         return res;
       }
       const res = Res.json({ status: "no-session" });

--- a/deno/server/inter/http/routes/auth/getSession.ts
+++ b/deno/server/inter/http/routes/auth/getSession.ts
@@ -10,8 +10,6 @@ export default (core: Core) =>
     url: "/session",
     handler: async (req) => {
       if (req.state.session) {
-        // Sliding expiration: extend the persisted session and re-issue the
-        // cookies with a fresh Max-Age so active users stay logged in.
         const expires = new Date(Date.now() + SESSION_TTL_SECONDS * 1000);
         await core.repo.session.refresh(req.state.session.id, expires);
 

--- a/deno/server/inter/http/routes/auth/postSession.ts
+++ b/deno/server/inter/http/routes/auth/postSession.ts
@@ -1,6 +1,7 @@
 import { Res, Route } from "@planigale/planigale";
 import { AccessDenied } from "../../errors.ts";
 import { Core } from "../../../../core/mod.ts";
+import { authCookieOptions } from "../../cookies.ts";
 
 export default (core: Core) =>
   new Route({
@@ -39,8 +40,9 @@ export default (core: Core) =>
         throw new AccessDenied("Invalid login or password");
       }
       const res = Res.json({ status: "ok", ...session, key: req.body.key });
-      res.cookies.set("token", session.token, { httpOnly: true, path: "/" });
-      res.cookies.set("key", req.body.key, { httpOnly: true, path: "/" });
+      const cookieOpts = authCookieOptions(core);
+      res.cookies.set("token", session.token, cookieOpts);
+      res.cookies.set("key", req.body.key, cookieOpts);
       return res;
     },
   });

--- a/migrations/20260616120000_sessions_add_expiry_and_token_index.ts
+++ b/migrations/20260616120000_sessions_add_expiry_and_token_index.ts
@@ -1,0 +1,43 @@
+import { Db, ObjectId } from "mongodb";
+
+// Keep in sync with deno/server/core/session/constants.ts (SESSION_TTL_SECONDS).
+const SESSION_TTL_MS = 60 * 60 * 24 * 60 * 1000; // 60 days
+
+export const up = async (db: Db) => {
+  // Backfill `expires` for sessions created before expiry existed so the TTL
+  // index can manage them (TTL ignores documents missing the field).
+  await db.collection("sessions").updateMany(
+    { expires: { $exists: false } },
+    [{ $set: { expires: { $add: ["$$NOW", SESSION_TTL_MS] } } }],
+  );
+
+  // Drop any duplicate tokens before enforcing uniqueness (legacy tokens were
+  // generated with Math.random()).
+  const duplicates: ObjectId[] = [];
+  const seen = new Set<string>();
+  const cursor = db.collection("sessions").find({});
+  for await (const session of cursor) {
+    if (typeof session.token !== "string") continue;
+    if (seen.has(session.token)) {
+      duplicates.push(session._id);
+    } else {
+      seen.add(session.token);
+    }
+  }
+  if (duplicates.length) {
+    await db.collection("sessions").deleteMany({ _id: { $in: duplicates } });
+  }
+
+  // TTL index: MongoDB removes a session once `expires` passes.
+  await db.collection("sessions").createIndex(
+    { expires: 1 },
+    { expireAfterSeconds: 0 },
+  );
+  // Tokens must be unique.
+  await db.collection("sessions").createIndex({ token: 1 }, { unique: true });
+};
+
+export const down = async (db: Db) => {
+  await db.collection("sessions").dropIndex("expires_1");
+  await db.collection("sessions").dropIndex("token_1");
+};

--- a/migrations/20260616120000_sessions_add_expiry_and_token_index.ts
+++ b/migrations/20260616120000_sessions_add_expiry_and_token_index.ts
@@ -1,18 +1,13 @@
 import { Db, ObjectId } from "mongodb";
 
-// Keep in sync with deno/server/core/session/constants.ts (SESSION_TTL_SECONDS).
-const SESSION_TTL_MS = 60 * 60 * 24 * 60 * 1000; // 60 days
+const SESSION_TTL_MS = 60 * 60 * 24 * 60 * 1000;
 
 export const up = async (db: Db) => {
-  // Backfill `expires` for sessions created before expiry existed so the TTL
-  // index can manage them (TTL ignores documents missing the field).
   await db.collection("sessions").updateMany(
     { expires: { $exists: false } },
     [{ $set: { expires: { $add: ["$$NOW", SESSION_TTL_MS] } } }],
   );
 
-  // Drop any duplicate tokens before enforcing uniqueness (legacy tokens were
-  // generated with Math.random()).
   const duplicates: ObjectId[] = [];
   const seen = new Set<string>();
   const cursor = db.collection("sessions").find({});
@@ -28,12 +23,10 @@ export const up = async (db: Db) => {
     await db.collection("sessions").deleteMany({ _id: { $in: duplicates } });
   }
 
-  // TTL index: MongoDB removes a session once `expires` passes.
   await db.collection("sessions").createIndex(
     { expires: 1 },
     { expireAfterSeconds: 0 },
   );
-  // Tokens must be unique.
   await db.collection("sessions").createIndex({ token: 1 }, { unique: true });
 };
 


### PR DESCRIPTION
## Summary

Users were being logged out frequently. Root cause: the `token` and `key` auth cookies were issued **without a `Max-Age`**, making them non-persistent *session cookies* that the browser (and especially the mobile/PWA WebView process) drops whenever it is closed or recycled. On the next visit the cookies were gone, session restore failed, and the client wiped its local state — forcing a fresh login.

This PR makes auth sessions durable on both the cookie and the server side. It is a self-contained first step (Phase 1 of a larger plan) and requires **no client changes** — the existing login/restore flow now simply survives restarts.

## Changes

- **Persistent auth cookies**: new shared `authCookieOptions` helper sets `Max-Age` (60 days), `SameSite=Lax`, and `Secure` (only when served over HTTPS, so local HTTP dev and tests are unaffected) on both the `token` and `key` cookies in `postSession` and `getSession`.
- **Server-side session expiry**: `expires` is now set on session create, slid forward on each `GET /session` (sliding expiration so active users never lapse), and a **MongoDB TTL index** cleans up expired sessions automatically. The `expires` field already existed on the `Session` type but was previously unused.
- **Stronger tokens**: session tokens now use `crypto.getRandomValues` (64 hex chars) instead of `Math.random()`, with a **unique index** on `token`.
- **Migration** (`20260616120000_...`): backfills `expires` for pre-existing sessions and dedupes any duplicate tokens before enforcing the unique index. Includes a `down()` that drops both indexes.

Note: the `key` cookie is intentionally kept (just made persistent) so the current client keeps working; removing the key-split is planned for a later phase alongside the corresponding client changes.

## Testing

- `deno fmt`, `deno lint`, and `deno check` (types) pass on all changed modules.
- `auth/__tests__/session.test.ts` updated for the new cookie attributes — 4 tests / 8 steps pass.
- Migration verified live against MongoDB: confirmed the TTL index (`expireAfterSeconds: 0` on `expires`), the unique `token` index, legacy-session `expires` backfill, and a clean `down()` revert.

> Heads-up: `deno task migrate:tests` currently aborts on a **pre-existing, unrelated** migration (`20241212...add-email-index`) due to duplicate `login: null` rows in the local test DB. Not introduced by this PR.