### PR TITLE
fix(storage): cache GCS access token for its real lifetime

### DIFF
--- a/deno/storage/src/core/store/gcs.ts
+++ b/deno/storage/src/core/store/gcs.ts
@@ -25,7 +25,7 @@ const API_URL = "https://storage.googleapis.com";
 class Gcs {
   bucketName: string;
 
-  accessToken: Promise<string | null | undefined> | null = null;
+  accessToken: string | null = null;
 
   accessTokenExpires = 0;
 
@@ -45,10 +45,10 @@ class Gcs {
     this.bucketName = config.bucket;
   }
 
-  getAccessToken() {
+  async getAccessToken() {
     if (!this.accessToken || Date.now() > this.accessTokenExpires) {
-      this.accessToken = this.auth.getAccessToken();
-      this.accessTokenExpires = Date.now() + 2 * 1000;
+      this.accessToken = await this.auth.getAccessToken() ?? null;
+      this.accessTokenExpires = Date.now() + 50 * 60 * 1000;
     }
     return this.accessToken;
   }


### PR DESCRIPTION
## Summary
The GCS access-token cache window was set to 2 seconds, which defeated the purpose of the cache: any two requests more than 2s apart re-entered the token-derivation branch. This caches the token for its real lifetime instead.

## Changes
- `getAccessToken()` now caches for **50 minutes** (under the ~1h GCS token lifetime) instead of 2 seconds.
- It now `await`s and stores the resolved token **string** rather than the pending promise, so a failed auth call is no longer cached as a rejected promise for the window — it retries on the next call.
- `accessToken` field type narrowed from `Promise<string | null | undefined> | null` to `string | null`.

## Testing
- `deno fmt --check` and `deno lint` on the changed file — pass.
- `deno test -A deno/storage/tests/` — 17 passed.
- No call-site changes needed: all callers already `await getAccessToken()`.