### PR TITLE
fix(sidebar): center mobile nav rows with flexbox to fix hover alignment

### DIFF
--- a/app/src/js/components/organisms/Sidebar.tsx
+++ b/app/src/js/components/organisms/Sidebar.tsx
@@ -32,29 +32,21 @@ const Container = styled.div`
     width: 100%;
     height: 100vh;
 
-    & .channel {
-      height: 40px;
-      line-height: 40px;
-      vertical-align: middle;
-      font-size: 20px;
-      & .name {
-        height: 40px;
-        line-height: 40px;
-        vertical-align: middle;
-        font-size: 20px;
-      }
-    }
+    & .channel,
     & .user {
-      height: 40px;
-      line-height: 40px;
-      vertical-align: middle;
+      display: flex;
+      align-items: center;
+      min-height: 40px;
       font-size: 20px;
-      & .name {
-        height: 40px;
-        line-height: 40px;
-        vertical-align: middle;
-        font-size: 20px;
-      }
+    }
+    & .channel .name,
+    & .user .name {
+      font-size: 20px;
+    }
+    & .user .text {
+      display: flex;
+      align-items: center;
+      margin: 0;
     }
   }
   &.hidden {


### PR DESCRIPTION
## Summary
Fixes vertical misalignment of channel and user rows in the mobile sidebar nav. The previous centering relied on fixed `height`/`line-height`/`vertical-align`, which drifted out of alignment (visible on hover). Rows now use flexbox centering so labels stay vertically centered regardless of content height.

## Changes
- Replace per-row fixed `height: 40px` + `line-height: 40px` + `vertical-align: middle` with `display: flex; align-items: center; min-height: 40px` on `.channel` and `.user` rows.
- Consolidate the duplicated channel/user style blocks into shared selectors.
- Center the `.user .text` wrapper with flexbox and drop its default margin.

## Testing
- `pnpm lint` on the changed file — no new errors (one pre-existing, unrelated type-import warning).
- CSS-only change; verified the mobile nav layout renders with rows vertically centered and hover state aligned.