### PR TITLE
feat(profile): profile settings modal (name + avatar) and move dev ports to 400x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,10 @@ deno task dev              # Run backend in watch mode
 deno task start            # Production start
 
 # Frontend (pnpm — installs go through Socket Firewall + 1-week cooldown)
-cd app && pnpm dev         # Vite dev server (port 3000, HTTPS via basic-ssl)
+cd app && pnpm dev         # Vite dev server (port 4000, HTTPS via basic-ssl; proxies /api → backend :4001)
 cd app && pnpm build       # Production build
 cd app && pnpm lint        # ESLint
-cd app && pnpm storybook   # Storybook (port 6006)
+cd app && pnpm storybook   # Storybook (port 4006)
 
 # Full stack
 deno task check            # fmt + lint + test (all backend)

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "types": "tsc --noEmit",
     "lint": "eslint src/ --ext .ts,.tsx",
-    "storybook": "storybook dev -p 6006 --no-open --host 0.0.0.0",
+    "storybook": "storybook dev -p 4006 --no-open --host 0.0.0.0",
     "build-storybook": "storybook build",
     "chromatic": "npx chromatic"
   },

--- a/app/src/js/components/molecules/LoggedUser.tsx
+++ b/app/src/js/components/molecules/LoggedUser.tsx
@@ -9,11 +9,28 @@ const Container = styled.div`
   padding: 12px;
   width: 100%;
 
+  .profile-trigger {
+    display: flex;
+    flex-direction: row;
+    gap: 12px;
+    flex: 1;
+    min-width: 0;
+    align-items: center;
+    cursor: pointer;
+    border-radius: 8px;
+    padding: 2px;
+    margin: -2px;
+
+    &:hover {
+      background-color: ${({ theme }) => theme.Channel.Hover};
+    }
+  }
   .profile-pic {
     flex: 0 0 32px;
   }
   .user-info {
     flex: 1;
+    min-width: 0;
     .name {
       color: ${(props) => props.theme.Text};
       font-size: 14px;
@@ -46,17 +63,22 @@ type LoggedUserProps = {
   name: string;
   avatarUrl?: string;
   onLogout: () => void;
+  onOpenSettings?: () => void;
 };
 
-export const LoggedUser = ({ name, avatarUrl, onLogout }: LoggedUserProps) => {
+export const LoggedUser = (
+  { name, avatarUrl, onLogout, onOpenSettings }: LoggedUserProps,
+) => {
   return (
     <Container>
-      <div className="profile-pic">
-        <ProfilePic type="personal" avatarUrl={avatarUrl} />
-      </div>
-      <div className="user-info">
-        <div className="name">{name}</div>
-        <div className="status">Online</div>
+      <div className="profile-trigger" onClick={onOpenSettings}>
+        <div className="profile-pic">
+          <ProfilePic type="personal" avatarUrl={avatarUrl} />
+        </div>
+        <div className="user-info">
+          <div className="name">{name}</div>
+          <div className="status">Online</div>
+        </div>
       </div>
       <div className="user-actions">
         <ButtonWithIcon

--- a/app/src/js/components/molecules/LoggedUserConnected.tsx
+++ b/app/src/js/components/molecules/LoggedUserConnected.tsx
@@ -4,22 +4,33 @@ import { useApp } from "../contexts/appState";
 import { getFileUrl } from "../hooks/fileUrl";
 import { LoggedUser } from "./LoggedUser";
 
-export const LoggedUserConnected = observer(() => {
-  const app = useApp();
-  const user = app.profile;
+type LoggedUserConnectedProps = {
+  onOpenSettings?: () => void;
+};
 
-  const avatarUrl = getFileUrl(user?.avatarFileId);
+export const LoggedUserConnected = observer(
+  ({ onOpenSettings }: LoggedUserConnectedProps) => {
+    const app = useApp();
+    const user = app.profile;
 
-  if (!user) {
-    return null;
-  }
+    const avatarUrl = getFileUrl(user?.avatarFileId);
 
-  const handleLogout = async () => {
-    await client.api.auth.logout();
-    document.location.reload();
-  };
+    if (!user) {
+      return null;
+    }
 
-  return (
-    <LoggedUser name={user.name} avatarUrl={avatarUrl} onLogout={handleLogout} />
-  );
-});
+    const handleLogout = async () => {
+      await client.api.auth.logout();
+      document.location.reload();
+    };
+
+    return (
+      <LoggedUser
+        name={user.name}
+        avatarUrl={avatarUrl}
+        onLogout={handleLogout}
+        onOpenSettings={onOpenSettings}
+      />
+    );
+  },
+);

--- a/app/src/js/components/organisms/ProfileSettings.stories.tsx
+++ b/app/src/js/components/organisms/ProfileSettings.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ProfileSettings } from "./ProfileSettings.tsx";
+import { app, client } from "../../core/index.ts";
+import { UserModel } from "../../core/models/user.ts";
+import type { User } from "../../types.ts";
+
+const seedProfile = (overrides: Partial<User> = {}) => {
+  app.profile = new UserModel({
+    id: "story-user",
+    alias: null,
+    email: "ada@example.com",
+    name: "Ada Lovelace",
+    avatarFileId: "",
+    publicKey: {} as JsonWebKey,
+    ...overrides,
+  }, app);
+
+  client.api.updateProfile = async (data: { name: string }) => {
+    app.profile?.patch({ ...app.profile, ...data } as User);
+    return { ...(app.profile as unknown as User), ...data };
+  };
+  client.api.uploadAvatar = async (file: File) => {
+    const avatarFileId = URL.createObjectURL(file);
+    app.profile?.patch({ ...app.profile, avatarFileId } as User);
+    return { ...(app.profile as unknown as User), avatarFileId };
+  };
+};
+
+const meta: Meta<typeof ProfileSettings> = {
+  component: ProfileSettings,
+  title: "Organisms/ProfileSettings",
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    onClose: {
+      action: "closed",
+      description: "Called when the modal is closed, cancelled, or saved",
+    },
+  },
+  loaders: [async () => seedProfile()],
+  render: (args) => <ProfileSettings {...args} />,
+};
+
+export default meta;
+type Story = StoryObj<typeof ProfileSettings>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const LongName: Story = {
+  args: {},
+  loaders: [async () =>
+    seedProfile({
+      name: "Augusta Ada King, Countess of Lovelace",
+      email: "augusta.ada.king@analytical-engine.example.com",
+    })],
+};

--- a/app/src/js/components/organisms/ProfileSettings.tsx
+++ b/app/src/js/components/organisms/ProfileSettings.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+import { observer } from "mobx-react-lite";
+import { Icon } from "../atoms/Icon";
+import {
+  ModalCloseButton,
+  ModalContainer,
+  ModalHeader,
+  ModalOverlay,
+} from "../atoms/Modal";
+import {
+  FormGroup,
+  FormHelpText,
+  FormInput,
+  FormLabel,
+} from "../atoms/FormInput";
+import { ProfilePic } from "../atoms/ProfilePic";
+import { Button } from "../molecules/Button";
+import { useApp } from "../contexts/appState";
+import { getFileUrl } from "../hooks/fileUrl";
+
+const ERROR_COLOR = "#e5484d";
+
+const Body = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const AvatarRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+
+  .avatar-edit {
+    position: relative;
+    cursor: pointer;
+    flex: 0 0 auto;
+
+    .overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      background-color: rgba(0, 0, 0, 0.45);
+      color: #fff;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    &:hover .overlay {
+      opacity: 1;
+    }
+  }
+`;
+
+const ActionRow = styled.div`
+  display: flex;
+  gap: 8px;
+
+  button {
+    flex: 1 1 0;
+  }
+`;
+
+const ErrorText = styled(FormHelpText)`
+  color: ${ERROR_COLOR};
+`;
+
+type ProfileSettingsProps = {
+  onClose: () => void;
+};
+
+export const ProfileSettings = observer(({ onClose }: ProfileSettingsProps) => {
+  const app = useApp();
+  const profile = app.profile;
+
+  const [name, setName] = useState(profile?.name ?? "");
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  if (!profile) return null;
+
+  const avatarUrl = previewUrl ?? getFileUrl(profile.avatarFileId);
+
+  const pickFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const picked = e.target.files?.[0] ?? null;
+    if (picked && !picked.type.startsWith("image/")) {
+      setError("Please choose an image file");
+      return;
+    }
+    setError(null);
+    setFile(picked);
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const submit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Name can't be empty");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (file) await app.uploadAvatar(file);
+      if (trimmed !== profile.name) await app.updateProfile(trimmed);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save profile");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ModalOverlay onClick={handleOverlayClick}>
+      <ModalContainer className="cmp-profile-settings">
+        <ModalHeader>
+          <h2>
+            <Icon icon="user" size={24} />
+            Profile settings
+          </h2>
+          <ModalCloseButton onClick={onClose} />
+        </ModalHeader>
+
+        <Body>
+          <AvatarRow>
+            <div
+              className="avatar-edit"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <ProfilePic type="regular" avatarUrl={avatarUrl} />
+              <div className="overlay">
+                <Icon icon="edit" size={18} />
+              </div>
+            </div>
+            <Button type="secondary" onClick={() => fileInputRef.current?.click()}>
+              Change avatar
+            </Button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              style={{ display: "none" }}
+              onChange={pickFile}
+            />
+          </AvatarRow>
+
+          <FormGroup>
+            <FormLabel htmlFor="profile-name">Name</FormLabel>
+            <FormInput
+              id="profile-name"
+              type="text"
+              value={name}
+              autoFocus
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submit();
+              }}
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <FormLabel htmlFor="profile-email">Email</FormLabel>
+            <FormInput id="profile-email" type="text" value={profile.email} disabled />
+            <FormHelpText>Email cannot be changed yet.</FormHelpText>
+          </FormGroup>
+
+          {error && <ErrorText>{error}</ErrorText>}
+
+          <ActionRow>
+            <Button type="secondary" onClick={onClose}>Cancel</Button>
+            <Button type="primary" onClick={submit} disabled={submitting}>
+              {submitting ? "Saving…" : "Save"}
+            </Button>
+          </ActionRow>
+        </Body>
+      </ModalContainer>
+    </ModalOverlay>
+  );
+});
+
+export default ProfileSettings;

--- a/app/src/js/components/organisms/Sidebar.tsx
+++ b/app/src/js/components/organisms/Sidebar.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { NavChannels } from "../molecules/NavChannels";
 import { NavUsers } from "../molecules/NavUsers";
 import { ClassNames, cn } from "../../utils";
 import styled from "styled-components";
 import { ThemeButtonConnected } from "../molecules/ThemeButtonConnected";
 import { LoggedUserConnected } from "../molecules/LoggedUserConnected";
+import { ProfileSettings } from "./ProfileSettings";
 import { observer } from "mobx-react-lite";
 
 const Container = styled.div`
@@ -69,6 +71,7 @@ export const Sidebar = observer(
       className?: ClassNames;
     },
   ) => {
+    const [showSettings, setShowSettings] = useState(false);
     return (
       <Container className={cn("side-menu", className)} style={style}>
         <div className="side-menu-header">
@@ -80,8 +83,11 @@ export const Sidebar = observer(
         </div>
         <div className="bottom">
           <ThemeButtonConnected />
-          <LoggedUserConnected />
+          <LoggedUserConnected onOpenSettings={() => setShowSettings(true)} />
         </div>
+        {showSettings && (
+          <ProfileSettings onClose={() => setShowSettings(false)} />
+        )}
       </Container>
     );
   },

--- a/app/src/js/core/models/app.ts
+++ b/app/src/js/core/models/app.ts
@@ -141,6 +141,18 @@ export class AppModel {
     return this._init;
   };
 
+  updateProfile = flow(function* (this: AppModel, name: string) {
+    const user = yield client.api.updateProfile({ name });
+    this.users.upsert(user);
+    return user;
+  });
+
+  uploadAvatar = flow(function* (this: AppModel, file: File) {
+    const user = yield client.api.uploadAvatar(file);
+    this.users.upsert(user);
+    return user;
+  });
+
   setLoading = (loading: boolean) => {
     if (loading) {
       clearTimeout(this.loadingTimeout);

--- a/app/src/js/core/models/user.ts
+++ b/app/src/js/core/models/user.ts
@@ -54,6 +54,11 @@ export class UserModel {
 
   patch = (value: User) => {
     this.name = value.name;
+    if (value.avatarFileId !== undefined) {
+      this.avatarFileId = value.avatarFileId;
+    }
+    if (value.alias !== undefined) this.alias = value.alias ?? null;
+    if (value.status !== undefined) this.status = value.status;
   };
 
   loadChannel = flow(function* (this: UserModel) {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -17,14 +17,14 @@ export default defineConfig(({ command }) => ({
   server: command === "serve"
     ? {
       host: true,
-      port: 3000,
+      port: 4000,
       strictPort: true,
       hmr: {
         overlay: false,
       },
       proxy: {
         "/api": {
-          target: "http://localhost:3001",
+          target: "http://localhost:4001",
           changeOrigin: true,
           secure: false,
         },

--- a/chat.config.example.ts
+++ b/chat.config.example.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@quack/config/define';
 import giphy from './plugins/giphy.ts';
 
 export default defineConfig({
-	port: 3001,
+	port: 4001,
   databaseUrl: 'mongodb://chat:chat@mongo:27017/chat?authSource=admin',
 	storage: {
 		type: 'fs',

--- a/deno/api/mod.ts
+++ b/deno/api/mod.ts
@@ -355,6 +355,41 @@ class API extends EventTarget {
   replaceEmoji = (shortname: string, file: File): Promise<Emoji> =>
     this.#uploadEmoji("PUT", shortname, file);
 
+  updateProfile = async (data: { name: string }): Promise<User> => {
+    const res = await this.fetchWithCredentials(`/api/profile`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(
+        body.message ?? `Failed to update profile (${res.status})`,
+      );
+    }
+    const { user } = await res.json();
+    return user;
+  };
+
+  uploadAvatar = async (file: File): Promise<User> => {
+    const res = await this.fetchWithCredentials(`/api/profile/avatar`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": file.type || "application/octet-stream",
+        "Content-Disposition": `attachment; filename="${file.name}"`,
+      },
+      body: file,
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(
+        body.message ?? `Failed to upload avatar (${res.status})`,
+      );
+    }
+    const { user } = await res.json();
+    return user;
+  };
+
   getMessages = async (
     q: {
       pinned?: boolean;

--- a/deno/config/base.ts
+++ b/deno/config/base.ts
@@ -17,7 +17,7 @@ export const from = async (path: string): Promise<Config> => {
 
 const __dirname = path.dirname(path.fromFileUrl(import.meta.url));
 const SECRETS_FILE: string = path.join(__dirname, "..", "..", "secrets.json");
-const PORT: number = parseInt(Deno.env.get("PORT") ?? "3001") || 3001;
+const PORT: number = parseInt(Deno.env.get("PORT") ?? "4001") || 4001;
 const DATABASE_URL = Deno.env.get("DATABASE_URL");
 const ENV = Deno.env.get("ENV_TYPE") || Deno.env.get("NODE_ENV");
 
@@ -51,7 +51,7 @@ const defaults: Partial<Config> = {
     type: "fs",
     directory: path.join(Deno.cwd(), "..", "..", "uploads"),
   },
-  baseUrl: "http://localhost:3001",
+  baseUrl: "http://localhost:4001",
 };
 
 const secrets = generateSecrets();

--- a/deno/server/core/core.ts
+++ b/deno/server/core/core.ts
@@ -34,6 +34,8 @@ import CheckChannelAccess from "./channel/checkAccess.ts";
 import InteractionWithMessage from "./message/interaction.ts";
 import ChannelUserTyping from "./channel/userTyping.ts";
 import UserReset from "./user/reset.ts";
+import SetProfile from "./user/setProfile.ts";
+import SetAvatar from "./user/setAvatar.ts";
 import RegisterFile from "./file/register.ts";
 import AttachFiles from "./file/attach.ts";
 import RemoveFile from "./file/remove.ts";
@@ -65,6 +67,8 @@ const commands = buildCommandCollection([
   InteractionWithMessage,
   ChannelUserTyping,
   UserReset,
+  SetProfile,
+  SetAvatar,
   RegisterFile,
   AttachFiles,
   RemoveFile,

--- a/deno/server/core/user/setAvatar.ts
+++ b/deno/server/core/user/setAvatar.ts
@@ -1,0 +1,30 @@
+import * as v from "valibot";
+import { createCommand } from "../command.ts";
+import { Id } from "../types.ts";
+
+export default createCommand({
+  type: "user:setAvatar",
+  body: v.object({
+    id: Id,
+    storageId: v.string(),
+  }),
+}, async ({ id, storageId }, { repo, storage, bus }) => {
+  const previous = await repo.user.getR({ id });
+  const oldAvatarFileId = previous.avatarFileId;
+
+  await repo.user.update({ id }, { avatarFileId: storageId });
+
+  if (oldAvatarFileId && oldAvatarFileId !== storageId) {
+    await storage.remove(oldAvatarFileId).catch(() => {});
+  }
+
+  const user = await repo.user.getR({ id });
+  bus.broadcast({
+    type: "user",
+    id: user.id,
+    name: user.name,
+    avatarFileId: user.avatarFileId,
+  });
+
+  return user.id;
+});

--- a/deno/server/core/user/setProfile.ts
+++ b/deno/server/core/user/setProfile.ts
@@ -1,0 +1,23 @@
+import * as v from "valibot";
+import { createCommand } from "../command.ts";
+import { Id } from "../types.ts";
+
+export default createCommand({
+  type: "user:setProfile",
+  body: v.object({
+    id: Id,
+    name: v.pipe(v.string(), v.trim(), v.minLength(1), v.maxLength(120)),
+  }),
+}, async ({ id, name }, { repo, bus }) => {
+  await repo.user.update({ id }, { name });
+  const user = await repo.user.getR({ id });
+
+  bus.broadcast({
+    type: "user",
+    id: user.id,
+    name: user.name,
+    avatarFileId: user.avatarFileId,
+  });
+
+  return user.id;
+});

--- a/deno/server/inter/http/routes/profile/__tests__/profile.test.ts
+++ b/deno/server/inter/http/routes/profile/__tests__/profile.test.ts
@@ -3,8 +3,30 @@ import { Agent } from "@planigale/testing";
 
 import { createApp } from "../../__tests__/app.ts";
 import { Chat } from "../../__tests__/chat.ts";
+import { login } from "../../__tests__/mod.ts";
 
 const { app, repo, core } = createApp();
+
+const PNG_BYTES = Uint8Array.from([
+  0x89,
+  0x50,
+  0x4e,
+  0x47,
+  0x0d,
+  0x0a,
+  0x1a,
+  0x0a,
+]);
+
+async function withPng(fn: (path: string) => Promise<void>) {
+  const path = await Deno.makeTempFile({ suffix: ".png" });
+  await Deno.writeFile(path, PNG_BYTES);
+  try {
+    await fn(path);
+  } finally {
+    await Deno.remove(path).catch(() => {});
+  }
+}
 
 Deno.env.set("APP_VERSION", "1.2.3");
 
@@ -28,5 +50,128 @@ Deno.test("GET /api/profile/config - getConfig", async () => {
         assertEquals(body.mainChannelId, admin.channelId);
       })
       .end();
+  });
+});
+
+Deno.test("PATCH /api/profile - unauthorized", async () => {
+  const agent = await Agent.from(app);
+  try {
+    await agent.request()
+      .patch("/api/profile")
+      .json({ name: "Nope" })
+      .expect(401);
+  } finally {
+    await agent.close();
+  }
+});
+
+Deno.test("PATCH /api/profile - updates the name", async () => {
+  const agent = await Agent.from(app);
+  try {
+    const { token } = await login(repo, agent, "profile-name");
+    const res = await agent.request()
+      .patch("/api/profile")
+      .json({ name: "Renamed User" })
+      .header("Authorization", `Bearer ${token}`)
+      .expect(200);
+    const { user } = await res.json();
+    assertEquals(user.name, "Renamed User");
+    assert(!("secrets" in user), "response must not leak secrets");
+    assert(!("password" in user), "response must not leak password");
+
+    const stored = await repo.user.getR({ email: "profile-name" });
+    assertEquals(stored.name, "Renamed User");
+  } finally {
+    await agent.close();
+  }
+});
+
+Deno.test("PATCH /api/profile - empty name rejected", async () => {
+  const agent = await Agent.from(app);
+  try {
+    const { token } = await login(repo, agent, "profile-empty");
+    await agent.request()
+      .patch("/api/profile")
+      .json({ name: "   " })
+      .header("Authorization", `Bearer ${token}`)
+      .expect([400, 422]);
+  } finally {
+    await agent.close();
+  }
+});
+
+Deno.test("PUT /api/profile/avatar - unauthorized", async () => {
+  await withPng(async (png) => {
+    const agent = await Agent.from(app);
+    try {
+      await agent.request()
+        .put("/api/profile/avatar")
+        .file(png)
+        .expect(401);
+    } finally {
+      await agent.close();
+    }
+  });
+});
+
+Deno.test("PUT /api/profile/avatar - sets avatarFileId", async () => {
+  await withPng(async (png) => {
+    const agent = await Agent.from(app);
+    try {
+      const { token } = await login(repo, agent, "avatar-set");
+      const res = await agent.request()
+        .put("/api/profile/avatar")
+        .file(png)
+        .header("Authorization", `Bearer ${token}`)
+        .expect(200);
+      const { user } = await res.json();
+      assert(user.avatarFileId, "avatarFileId should be set");
+      assert(!("secrets" in user), "response must not leak secrets");
+      assertEquals(await core.storage.exists(user.avatarFileId), true);
+    } finally {
+      await agent.close();
+    }
+  });
+});
+
+Deno.test("PUT /api/profile/avatar - non-image rejected", async () => {
+  const agent = await Agent.from(app);
+  try {
+    const { token } = await login(repo, agent, "avatar-bad");
+    await agent.request()
+      .put("/api/profile/avatar")
+      .text("not an image")
+      .header("Authorization", `Bearer ${token}`)
+      .expect(400);
+  } finally {
+    await agent.close();
+  }
+});
+
+Deno.test("PUT /api/profile/avatar - replaces and removes the old blob", async () => {
+  await withPng(async (png) => {
+    const agent = await Agent.from(app);
+    try {
+      const { token } = await login(repo, agent, "avatar-swap");
+      const first = await agent.request()
+        .put("/api/profile/avatar")
+        .file(png)
+        .header("Authorization", `Bearer ${token}`)
+        .expect(200);
+      const firstId = (await first.json()).user.avatarFileId;
+
+      const second = await agent.request()
+        .put("/api/profile/avatar")
+        .file(png)
+        .header("Authorization", `Bearer ${token}`)
+        .expect(200);
+      const secondId = (await second.json()).user.avatarFileId;
+
+      assert(firstId !== secondId, "a new blob should be stored");
+      assertEquals(await core.storage.exists(firstId), false);
+      assertEquals(await core.storage.exists(secondId), true);
+    } finally {
+      await agent.close();
+    }
   });
 });

--- a/deno/server/inter/http/routes/profile/avatar.ts
+++ b/deno/server/inter/http/routes/profile/avatar.ts
@@ -1,0 +1,56 @@
+import { Route } from "@planigale/planigale";
+import { Core } from "../../../../core/mod.ts";
+import { EntityId } from "../../../../types.ts";
+import { serializeUser } from "../users/_serializeUser.ts";
+
+type AvatarUploadMeta = {
+  filename: string;
+  contentType: string;
+  size: number;
+};
+
+function parseMeta(
+  req: { headers: Record<string, string | undefined> },
+): AvatarUploadMeta | Response {
+  const contentType = req.headers["content-type"] ?? "application/octet-stream";
+  if (!contentType.startsWith("image/")) {
+    return Response.json(
+      { errorCode: "INVALID_AVATAR", message: "expected an image" },
+      { status: 400 },
+    );
+  }
+  const disposition = req.headers["content-disposition"] ?? "";
+  const match = disposition.match(/filename\*?=(?:UTF-8'')?"?([^"]+)"?/i);
+  const filename = (match?.[1] ?? "avatar")
+    .replace(/[\r\n"\\/]/g, "_")
+    .slice(0, 255);
+  const size = parseInt(req.headers["content-length"] ?? "0", 10);
+  return { filename, contentType, size };
+}
+
+export default (core: Core) =>
+  new Route({
+    method: "PUT",
+    url: "/avatar",
+    public: false,
+    handler: async (req) => {
+      const meta = parseMeta(req);
+      if (meta instanceof Response) return meta;
+
+      const userId = req.state.user.id;
+      const storageId = await core.storage.upload(req.body, meta);
+      try {
+        await core.dispatch(
+          {
+            type: "user:setAvatar",
+            body: { id: userId, storageId },
+          } as Parameters<Core["dispatch"]>[0],
+        ).internal();
+        const user = await core.repo.user.getR({ id: EntityId.from(userId) });
+        return Response.json({ status: "ok", user: serializeUser(user) });
+      } catch (e) {
+        await core.storage.remove(storageId).catch(() => {});
+        throw e;
+      }
+    },
+  });

--- a/deno/server/inter/http/routes/profile/mod.ts
+++ b/deno/server/inter/http/routes/profile/mod.ts
@@ -2,9 +2,13 @@ import { Router } from "@planigale/planigale";
 import { Core } from "../../../../core/mod.ts";
 
 import config from "./config.ts";
+import update from "./update.ts";
+import avatar from "./avatar.ts";
 
 export const profile = (core: Core) => {
   const router = new Router();
   router.use(config(core));
+  router.use(update(core));
+  router.use(avatar(core));
   return router;
 };

--- a/deno/server/inter/http/routes/profile/update.ts
+++ b/deno/server/inter/http/routes/profile/update.ts
@@ -1,0 +1,38 @@
+import { Route } from "@planigale/planigale";
+import { Core } from "../../../../core/mod.ts";
+import { EntityId } from "../../../../types.ts";
+import { serializeUser } from "../users/_serializeUser.ts";
+
+export default (core: Core) =>
+  new Route({
+    method: "PATCH",
+    url: "/",
+    public: false,
+    schema: {
+      body: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string", minLength: 1, maxLength: 120 },
+        },
+      },
+    },
+    handler: async (req) => {
+      const userId = req.state.user.id;
+      const name = String(req.body.name).trim();
+      if (!name) {
+        return Response.json(
+          { errorCode: "INVALID_NAME", message: "name cannot be empty" },
+          { status: 400 },
+        );
+      }
+      await core.dispatch(
+        {
+          type: "user:setProfile",
+          body: { id: userId, name },
+        } as Parameters<Core["dispatch"]>[0],
+      ).internal();
+      const user = await core.repo.user.getR({ id: EntityId.from(userId) });
+      return Response.json({ status: "ok", user: serializeUser(user) });
+    },
+  });

--- a/deno/tools/export-mobile-config.ts
+++ b/deno/tools/export-mobile-config.ts
@@ -13,7 +13,7 @@ import { join } from "@std/path";
 const isLocalDev = config.baseUrl.includes("localhost") ||
   config.baseUrl.includes("127.0.0.1");
 const serverUrl = isLocalDev
-  ? config.baseUrl.replace(":3001", ":3000").replace("http://", "https://") // Frontend dev server (HTTPS via basic-ssl)
+  ? config.baseUrl.replace(":4001", ":4000").replace("http://", "https://") // Frontend dev server (HTTPS via basic-ssl)
   : config.baseUrl;
 
 const mobileConfig = {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,7 +86,7 @@ Business logic organized by domain aggregate:
 |--------|----------|---------|
 | `channel/` | create, remove, join, leave, getDirect, putDirect | list, get |
 | `message/` | create, update, remove, react, pin | list, search, get |
-| `user/` | create, resetPassword, verifyReset, checkToken | list, get |
+| `user/` | create, resetPassword, verifyReset, checkToken, setProfile, setAvatar | list, get |
 | `session/` | create, remove | get |
 | `emoji/` | create, remove | list |
 | `readReceipt/` | update | list |
@@ -118,7 +118,7 @@ Interface layer exposing the core via HTTP:
 - **`http/mod.ts`** — `HttpInterface` class extending the Planigale framework. Builds all routes, applies middleware, serves static frontend files.
 - **`http/middleware/auth.ts`** — Session-based authentication middleware.
 - **`http/errors.ts`** — Maps domain `AppError` subclasses to HTTP status codes.
-- **`http/routes/`** — Route modules organized by domain: `auth/`, `channels/`, `messages/`, `users/`, `emojis/`, `files/`, `system/`, `mobile/`.
+- **`http/routes/`** — Route modules organized by domain: `auth/`, `channels/`, `messages/`, `users/`, `profile/`, `emojis/`, `files/`, `system/`, `mobile/`.
 - **`cli/mod.ts`** — Minimal CLI interface.
 
 **Route pattern:** Each route file exports `(core: Core) => new Route({ method, url, schema, handler })`.

--- a/docs/mobile-app.md
+++ b/docs/mobile-app.md
@@ -85,7 +85,7 @@ For local development with HTTPS (required for service workers):
 3. Configure mobile to use local dev server:
    ```bash
    cd mobile
-   export QUACK_SERVER_URL="https://localhost:3000"
+   export QUACK_SERVER_URL="https://localhost:4000"
    npm run cap:sync
    ```
 
@@ -156,7 +156,7 @@ Edit `mobile/capacitor.config.ts`:
 
 ### Local development issues
 1. Ensure SSL certificate is installed on emulator
-2. Verify frontend dev server is running on port 3000
+2. Verify frontend dev server is running on port 4000
 3. Check that `QUACK_SERVER_URL` is set correctly
 
 ## Architecture

--- a/mobile/android/app/src/main/assets/capacitor.config.json
+++ b/mobile/android/app/src/main/assets/capacitor.config.json
@@ -3,7 +3,7 @@
 	"appName": "Quack",
 	"webDir": "www",
 	"server": {
-		"url": "https://10.0.2.2:3000",
+		"url": "https://10.0.2.2:4000",
 		"cleartext": false
 	},
 	"android": {


### PR DESCRIPTION
## Summary
Adds a **Profile Settings** modal so users can change their display name and upload an avatar, re-adding avatar support that was dropped during the files-root-entity work — decoupled from channel `File` entities so profile assets never pollute the channel Files view. Also moves the **local dev ports into the 400x range** to avoid a collision on port 3000.

## Changes

### Profile settings (feature)
**Backend**
- `user:setProfile` and `user:setAvatar` commands, each broadcasting `{type:"user"}` over the existing SSE pipeline.
- `PATCH /api/profile` (name) and `PUT /api/profile/avatar` (raw image stream → `core.storage.upload`), mounted on the existing profile router.
- Both responses go through `serializeUser`, so `secrets`/password hash never leak; `setAvatar` best-effort removes the previous blob.
- Avatar/name upload via `storage` directly — **no channel `File` entity created**.

**Frontend**
- New `ProfileSettings` organism (opened from the sidebar user entry) + Storybook story.
- `AppModel.updateProfile` / `uploadAvatar` actions and API client methods.
- `UserModel.patch` now also applies `avatarFileId`/`alias`/`status`, so avatar changes render live via SSE (previously it only patched `name`).
- Modal lifted into the `Sidebar` organism to respect the atomic-design import hierarchy (molecules must not import organisms).
- Email is shown **read-only** — it is the PBKDF2 salt for both the auth hash and the encryption key, so changing it is a separate crypto-migration, not a profile field.

### Dev ports (chore)
- Frontend `3000→4000`, backend `3001→4001`, Storybook `6006→4006`.
- Updates the Vite `/api` proxy target, backend `PORT`/`baseUrl` defaults, mobile-config dev-URL rewrite, capacitor config, and docs. The `PORT` env override (e.g. Docker's `8080`) is unchanged.

### Docs
- `ARCHITECTURE.md`: add the new `user/` commands and the `profile/` route module.
- Port references updated in `CLAUDE.md` and `docs/mobile-app.md`.

## Testing
- Added `deno` route tests for the profile endpoints (auth, name update, empty-name rejection, avatar set, non-image rejection, blob replacement, plus assertions that responses don't leak secrets) — **9/9 pass**.
- Emoji + command suites still green (20/20) after the command-collection change.
- `deno check` / `deno lint` / `deno fmt` clean; frontend `pnpm types` shows no new errors; ESLint clean on changed files; `build-storybook` compiles with the new story.