### PR TITLE
fix(storage): make GCS uploads resilient to network/DNS stalls

### DIFF
--- a/deno/server/inter/http/mod.ts
+++ b/deno/server/inter/http/mod.ts
@@ -46,7 +46,13 @@ export class HttpInterface extends Planigale {
         const start = Date.now();
         const ret = await next();
         const time = Date.now() - start;
-        //console.log(req.method, req.url, ret.status, time + "ms");
+        const status = ret instanceof Response ? ret.status : undefined;
+        const line = `${req.method} ${req.url} ${status ?? "-"} ${time}ms`;
+        if ((status !== undefined && status >= 500) || time >= 2000) {
+          console.warn(`[http] ${line}`);
+        } else {
+          console.log(`[http] ${line}`);
+        }
         return ret;
       });
       this.use(errorHandler);

--- a/deno/storage/src/core/store/gcs.ts
+++ b/deno/storage/src/core/store/gcs.ts
@@ -2,6 +2,7 @@
 import { GoogleAuth } from "google-auth-library";
 import { ResourceNotFound } from "@planigale/planigale";
 import type { FileData, FileMeta, FileOpts, Resolution } from "../types.ts";
+import { getEnvInt } from "../env.ts";
 
 function parseResolution(raw: unknown): Resolution | null {
   if (typeof raw !== "string") return null;
@@ -21,6 +22,96 @@ function parseResolution(raw: unknown): Resolution | null {
 
 // const API_URL = "http://localhost:8888";
 const API_URL = "https://storage.googleapis.com";
+
+const GCS_TIMEOUT_MS = getEnvInt("STORAGE_GCS_TIMEOUT_MS", 20_000);
+const GCS_UPLOAD_TIMEOUT_MS = getEnvInt(
+  "STORAGE_GCS_UPLOAD_TIMEOUT_MS",
+  60_000,
+);
+const GCS_MAX_RETRIES = getEnvInt("STORAGE_GCS_MAX_RETRIES", 3);
+const GCS_BUFFER_LIMIT_BYTES = getEnvInt(
+  "STORAGE_GCS_BUFFER_LIMIT_BYTES",
+  64 * 1024 * 1024,
+);
+
+const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
+
+function backoff(attempt: number): Promise<void> {
+  const ms = Math.min(500 * 2 ** attempt, 5_000) +
+    Math.floor(Math.random() * 250);
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () =>
+        reject(
+          new DOMException(`${label} timed out after ${ms}ms`, "TimeoutError"),
+        ),
+      ms,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+async function gcsFetch(
+  url: string,
+  init: RequestInit,
+  opts: { label: string; timeoutMs?: number; retries?: number },
+): Promise<Response> {
+  const timeoutMs = opts.timeoutMs ?? GCS_TIMEOUT_MS;
+  const retries = opts.retries ?? GCS_MAX_RETRIES;
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (attempt > 0) await backoff(attempt - 1);
+    const started = Date.now();
+    try {
+      const res = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (RETRYABLE_STATUS.has(res.status) && attempt < retries) {
+        await res.body?.cancel?.();
+        lastError = new Error(`GCS ${opts.label} returned ${res.status}`);
+        console.warn(
+          `[storage][gcs] ${opts.label} status ${res.status}, retrying (${
+            attempt + 1
+          }/${retries})`,
+        );
+        continue;
+      }
+      return res;
+    } catch (err) {
+      lastError = err;
+      const reason = err instanceof Error ? err.name : String(err);
+      console.warn(
+        `[storage][gcs] ${opts.label} failed after ${
+          Date.now() - started
+        }ms (${reason}), attempt ${attempt + 1}/${retries + 1}`,
+      );
+    }
+  }
+  console.error(
+    `[storage][gcs] ${opts.label} gave up after ${retries + 1} attempts`,
+  );
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`GCS ${opts.label} failed`);
+}
 
 class Gcs {
   bucketName: string;
@@ -47,23 +138,47 @@ class Gcs {
 
   async getAccessToken() {
     if (!this.accessToken || Date.now() > this.accessTokenExpires) {
-      this.accessToken = await this.auth.getAccessToken() ?? null;
+      this.accessToken = await this.fetchAccessToken();
       this.accessTokenExpires = Date.now() + 50 * 60 * 1000;
     }
     return this.accessToken;
   }
 
+  private async fetchAccessToken(): Promise<string | null> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= GCS_MAX_RETRIES; attempt++) {
+      if (attempt > 0) await backoff(attempt - 1);
+      try {
+        const token = await withTimeout(
+          this.auth.getAccessToken(),
+          GCS_TIMEOUT_MS,
+          "auth token",
+        );
+        return token ?? null;
+      } catch (err) {
+        lastError = err;
+        const reason = err instanceof Error ? err.name : String(err);
+        console.warn(
+          `[storage][gcs] auth token fetch failed (${reason}), attempt ${
+            attempt + 1
+          }/${GCS_MAX_RETRIES + 1}`,
+        );
+      }
+    }
+    console.error("[storage][gcs] auth token fetch gave up");
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("GCS auth token fetch failed");
+  }
+
   async exists(fileId: string): Promise<boolean> {
     const token = await this.getAccessToken();
-    const meta = await fetch(
-      this.getUrl(fileId),
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+    const meta = await gcsFetch(this.getUrl(fileId), {
+      headers: {
+        Authorization: `Bearer ${token}`,
       },
-    );
-    await meta.json();
+    }, { label: "exists" });
+    await meta.body?.cancel?.();
     if (meta.status !== 200) {
       return false;
     }
@@ -79,21 +194,31 @@ class Gcs {
     const fileId = file?.id ?? crypto.randomUUID();
     const token = await this.getAccessToken();
 
-    const res = await fetch(this.getUploadUrl(fileId), {
-      // client: this.client,
+    const knownSize = typeof file.size === "number" ? file.size : undefined;
+    const canBuffer = knownSize !== undefined &&
+      knownSize <= GCS_BUFFER_LIMIT_BYTES;
+    const body: BodyInit = canBuffer
+      ? new Uint8Array(await new Response(webStream).arrayBuffer())
+      : webStream;
+
+    const res = await gcsFetch(this.getUploadUrl(fileId), {
       headers: {
         "Content-Type": file.contentType,
         Authorization: `Bearer ${token}`,
       },
       method: "POST",
-      body: webStream,
+      body,
+    }, {
+      label: "upload",
+      timeoutMs: GCS_UPLOAD_TIMEOUT_MS,
+      retries: canBuffer ? GCS_MAX_RETRIES : 0,
     });
     await res.body?.cancel?.();
     if (res.status !== 200) {
       throw new Error("Upload failed");
     }
 
-    const meta = await fetch(this.getUrl(fileId), {
+    const meta = await gcsFetch(this.getUrl(fileId), {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
@@ -107,7 +232,7 @@ class Gcs {
             : {}),
         },
       }),
-    });
+    }, { label: "metadata patch" });
     await meta.body?.cancel?.();
     if (meta.status !== 200) {
       throw new Error("Upload failed");
@@ -118,11 +243,11 @@ class Gcs {
 
   async stat(fileId: string): Promise<FileMeta> {
     const token = await this.getAccessToken();
-    const meta = await fetch(this.getUrl(fileId), {
+    const meta = await gcsFetch(this.getUrl(fileId), {
       headers: {
         Authorization: `Bearer ${token}`,
       },
-    });
+    }, { label: "stat" });
     const metadata = await meta.json();
     if (meta.status !== 200) {
       throw new ResourceNotFound("File not found");
@@ -139,7 +264,7 @@ class Gcs {
 
   async list(prefix: string): Promise<string[]> {
     const token = await this.getAccessToken();
-    const res = await fetch(
+    const res = await gcsFetch(
       `${API_URL}/storage/v1/b/${this.bucketName}/o?prefix=${
         encodeURIComponent(prefix)
       }`,
@@ -148,6 +273,7 @@ class Gcs {
           Authorization: `Bearer ${token}`,
         },
       },
+      { label: "list" },
     );
     const data = await res.json();
     if (res.status !== 200) {
@@ -158,13 +284,13 @@ class Gcs {
 
   async remove(fileId: string): Promise<void> {
     const token = await this.getAccessToken();
-    const meta = await fetch(this.getUrl(fileId), {
+    const meta = await gcsFetch(this.getUrl(fileId), {
       method: "DELETE",
       headers: {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({}),
-    });
+    }, { label: "remove" });
     await meta.body?.cancel?.();
     if (meta.status !== 200 && meta.status !== 204) {
       throw new Error("Delete failed");
@@ -173,25 +299,27 @@ class Gcs {
 
   get = async (fileId: string): Promise<FileData> => {
     const token = await this.getAccessToken();
-    const meta = await fetch(
+    const meta = await gcsFetch(
       this.getUrl(fileId),
       {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       },
+      { label: "get metadata" },
     );
     const metadata = await meta.json();
     if (meta.status !== 200) {
       throw new ResourceNotFound("File not found");
     }
-    const res = await fetch(
+    const res = await gcsFetch(
       metadata.mediaLink,
       {
         headers: {
           Authorization: `Bearer ${token}`,
         },
       },
+      { label: "get media", timeoutMs: GCS_UPLOAD_TIMEOUT_MS },
     );
     if (res.status !== 200 || res.body === null) {
       await res.body?.cancel();


### PR DESCRIPTION
## Problem

Prod file uploads (`chat.codecat.io`) intermittently fail: the progress bar fills but never turns green, then the message send fails. It came and went over whole days and self-healed, with no app-level error logs.

## Root cause

Uploads are streamed to **GCS** during the request, and the GCS client made 2–3 sequential outbound calls to Google (auth token → object POST → metadata PATCH) with **no timeout and no retry**. Any transient stall in the container's egress/DNS path (single upstream resolver via Docker's embedded DNS, plus parallel A/AAAA lookups) made those `fetch` calls hang indefinitely — hanging the whole upload with nothing logged.

Amplifier: the **deployed `main` cached the GCS access token for only 2 seconds**, so nearly every upload re-authenticated against `oauth2.googleapis.com`, multiplying the round-trips that could stall. (`dev` already caches for 50 min; this PR keeps that and hardens the rest.)

## Changes

- **`gcs.ts`** — every GCS request (auth token, upload POST, metadata PATCH, stat, list, get, remove, exists) now goes through a `gcsFetch` wrapper with a **per-attempt `AbortSignal.timeout` + bounded retries + exponential backoff**. A stalled path aborts and retries instead of hanging; transient 429/5xx are retried.
  - Upload payloads within a size limit are buffered so a failed attempt can be safely replayed; larger files stream in a single attempt (no unbounded memory).
- **`http/mod.ts`** — re-enabled concise HTTP access logging (`method url status latency`), escalated to `warn` on 5xx or `>=2s`, so upload issues are visible instead of silent.

Configurable via `STORAGE_GCS_TIMEOUT_MS`, `STORAGE_GCS_UPLOAD_TIMEOUT_MS`, `STORAGE_GCS_MAX_RETRIES`, `STORAGE_GCS_BUFFER_LIMIT_BYTES`.

## Testing

- `deno fmt` / `deno lint` / `deno check` clean on both files.
- Verified end-to-end against the real GCS bucket from inside the prod container: upload 200, stat, get (bytes match), remove, exists-after-remove — all correct via the new buffered/retry path.

## Deployment note

The deployed `main` also carries the 2-second token-cache bug (fixed on `dev`), so shipping this via `dev → main` also delivers that fix. For immediate prod relief, this commit can be cherry-picked onto a hotfix branch off `main`.

## Related infra (out of scope for this PR)

Host-level IPv6 was misconfigured (rogue ULA RAs from smart-home/RPi devices); the servers now ignore RAs (`accept_ra=0`). That's hygiene — this code change is what makes uploads resilient regardless of the network path.