### PR TITLE
fix(docker): repair release image build (drop sfw, fix pnpm/node/jsr)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,11 @@ jobs:
     - name: Frontend lint
       working-directory: app
       run: pnpm lint
+    - name: Frontend build
+      working-directory: app
+      run: pnpm build
+      env:
+        APP_NAME: quack
+        APP_VERSION: ${{ github.sha }}
     - run: deno task migrate:tests
     - run: deno task check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:22.12-alpine AS build
+FROM node:22-alpine AS build
 RUN mkdir -p /app
 WORKDIR /app
 COPY . .
 WORKDIR /app/app
-RUN corepack enable && npm i -g sfw
-RUN sfw pnpm install --frozen-lockfile
+RUN npm i -g pnpm@11.5.3
+RUN pnpm install --frozen-lockfile
 ENV APP_NAME=quack
 ARG APP_VERSION=3.x.x
 ENV APP_VERSION=$APP_VERSION

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -36,6 +36,10 @@ export default defineConfig(({ command }) => ({
       "@quack/encryption": path.resolve(__dirname, "../deno/encryption/mod.ts"),
       "@quack/api": path.resolve(__dirname, "../deno/api/mod.ts"),
       "@quack/tools": path.resolve(__dirname, "../deno/tools/mod.ts"),
+      "@jsr/planigale__sse": path.resolve(
+        __dirname,
+        "node_modules/@jsr/planigale__sse",
+      ),
     },
   },
   plugins: [


### PR DESCRIPTION
## Problem

The v3.7.0 release image build (and the dev image build) fails. Removing Socket Firewall — as requested — uncovered a stack of build breakages that shipped into `dev` unnoticed, because **CI only lints the frontend (never `pnpm build`)** and the Docker build was dying at `sfw` before it ever reached the frontend build.

Four layered failures:

| # | Breakage | Cause |
|---|----------|-------|
| 1 | `sfw` binary won't run on Alpine/musl | Socket's runtime binary (external) |
| 2 | `corepack` signature verify fails | stale signing keys baked into old `node:22.12` |
| 3 | `pnpm@11.5.3` needs Node ≥ 22.13 | new `packageManager` pin vs `node:22.12` base |
| 4 | rollup can't resolve `@jsr/planigale__sse` | new hardened `pnpm-workspace.yaml` (`nodeLinker: hoisted`) + the build imports `deno/api` from outside `app/` |

(#2–#4 all came in with the supply-chain-hardening changes that are part of v3.7.0.)

## Changes

- **`Dockerfile`**
  - Drop `sfw` from the image build. The supply-chain scan still runs in CI (`tests.yml` via the pinned `socketdev/action`), and `--frozen-lockfile` installs only already-vetted pinned deps.
  - Base `node:22.12-alpine` → `node:22-alpine` (satisfies pnpm's Node ≥22.13, ships corepack with valid keys).
  - Install the pinned pnpm directly (`npm i -g pnpm@11.5.3`) instead of corepack.
- **`app/vite.config.ts`** — alias `@jsr/planigale__sse` to `app/node_modules/...` so rollup resolves it when bundling `../deno/api/mod.ts` (planigale is our own package; it's meant to be bundled into the client).
- **`.github/workflows/tests.yml`** — add a `pnpm build` step so the frontend production build is gated in CI. This is what would have caught #4 before release.

## Verification

- `docker build .` (full image, all 29 steps) completes green locally — `pnpm install`, `pnpm build` (frontend), and the deno runtime stage all succeed.

## Note

Supply-chain posture is unchanged: `sfw` still scans dependencies on every PR in `tests.yml`; it's only removed from the image build where it was redundant and currently broken.