### PR TITLE
fix(ci): pin QEMU version to fix arm64 multi-arch build

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Problem

The multi-arch image build fails on the **arm64** leg with:

```
#35 qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```

The prod cluster is **aarch64**, so arm64 is the real deployment target — not droppable. The arm64 image is built by QEMU-emulating on the amd64 runner, and `docker/setup-qemu-action@v3`'s default binfmt ships a QEMU too old to emulate the newer Node/V8 in the `node:22-alpine` build stage (introduced when the release image build was repaired in the previous PR).

## Fix

Pin `tonistiigi/binfmt:qemu-v9.2.2` in `setup-qemu-action` for both the dev and release image workflows.

## Verification

Reproduced locally with binfmt/QEMU:
- Default/old QEMU: newer Node/V8 crashes under arm64 emulation.
- `qemu-v9.2.2`: `node:22-alpine` runs, and the **full `pnpm install --frozen-lockfile` + `pnpm build` completes under arm64 emulation** (`✓ built`, PWA generated).

## Follow-up (not in this PR)

Longer term, building the arm64 leg on a **native arm64 runner** (`ubuntu-24.04-arm`) would drop QEMU entirely — faster and no emulation fragility. Left as a separate change.