### PR TITLE
fix(pwa): auto-update service worker so clients receive new deploys

### DIFF
--- a/app/src/sw.ts
+++ b/app/src/sw.ts
@@ -12,6 +12,11 @@ if (files.length) {
   precacheAndRoute(files);
   navigationPreload.enable();
 }
+
+self.skipWaiting();
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
 /*
 
 const shareTargetHandler = async ({ event }) => {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig(({ command }) => ({
     command === "serve" && basicSsl(),
     VitePWA({
       injectRegister: "auto",
+      registerType: "autoUpdate",
       strategies: "injectManifest",
       srcDir: "./src",
       filename: "sw.ts",


### PR DESCRIPTION
## Summary

Makes the PWA service worker **auto-update** so a new deploy actually reaches open clients, instead of leaving them stranded on a stale cached bundle.

## Problem

`app/src/sw.ts` never called `skipWaiting()`/`clientsClaim()`, and `VitePWA` ran with the default `registerType: "prompt"` and no prompt wired up. So when a new version deployed, the new service worker installed but stayed in the **waiting** state — the old worker kept controlling open tabs and serving the old JS bundle indefinitely (until every tab/PWA for the origin was closed).

This is what caused the "Firefox-only file-upload 500": that browser was still running a **pre-#302** frontend that uploaded multipart `FormData` to `POST /api/files`, whose route was since rewritten to require a `Content-Disposition` header and now throws (`undefined.split(...)` → 500) on the old-style request. Chromium had cycled and picked up the new frontend (raw upload to `/api/channels/:id/files`), so it worked. Image loading (`GET /api/files/:id`, unchanged) worked in both, which is why only uploads broke and only in one browser.

## Change

- `vite.config.ts`: `registerType: "autoUpdate"` — the injected registration detects a new worker and reloads the page.
- `sw.ts`: `self.skipWaiting()` + claim clients on `activate` — the new worker activates immediately and takes over open tabs.

Uses the native service-worker APIs (`skipWaiting` / `self.clients.claim()`) rather than `clientsClaim()` from `workbox-core`, to avoid adding a new dependency (only `workbox-precaching`/`-routing`/`-strategies`/`-navigation-preload` are currently pulled in).

## Validation

- `pnpm build` succeeds; PWA injectManifest generates `dist/sw.js` containing both `skipWaiting()` and `clients.claim()`, and `registerSW` is injected into `index.html`.
- `pnpm lint` clean (0 errors). (The pre-existing `pnpm types` failures in `deno/tools/*` are unrelated to this change and also present on `dev`.)

## Caveat

This only fixes clients **going forward**. Anyone already stuck on the pre-fix worker (e.g. the Firefox that hit the 500) is still running the old worker with no auto-update and must unregister it / clear site data **once**. Every deploy after that applies automatically.
