### PR TITLE
Release v3.7.3

### DIFF
--- a/app/src/sw.ts
+++ b/app/src/sw.ts
@@ -12,6 +12,11 @@ if (files.length) {
   precacheAndRoute(files);
   navigationPreload.enable();
 }
+
+self.skipWaiting();
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
 /*
 
 const shareTargetHandler = async ({ event }) => {

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig(({ command }) => ({
     command === "serve" && basicSsl(),
     VitePWA({
       injectRegister: "auto",
+      registerType: "autoUpdate",
       strategies: "injectManifest",
       srcDir: "./src",
       filename: "sw.ts",


### PR DESCRIPTION
## Release v3.7.3

Patch release: makes the PWA update itself so clients stop getting stranded on stale bundles.

## Changes

- **Auto-update service worker** (#318) — the service worker never called `skipWaiting()`/`clientsClaim()` and VitePWA used the default "prompt" register mode with no prompt wired, so a new deploy stayed in the *waiting* state and open clients kept serving the old cached bundle indefinitely (the "close every tab to get the update" trap). This is what produced the Firefox-only file-upload 500 — a stranded pre-#302 frontend posting multipart to the old `/api/files` route, which now expects a `Content-Disposition` header. The worker now skips waiting and claims clients on activate (`registerType: "autoUpdate"`), so a new build takes over on the next reload/navigation.

## Deploy notes

- No config, dependency, or migration changes (native SW APIs; no new `workbox-core` dependency).
- **One-time caveat:** this only auto-applies to clients *going forward*. Anyone already stuck on the pre-fix worker (e.g. the Firefox that hit the 500) must unregister the service worker / clear site data **once**; every deploy after that applies on the next reload without intervention.
- Follow-up still open (not in this release): optionally force-reload open tabs and poll for updates so long-idle tabs refresh without a manual reload.
